### PR TITLE
ci: add GitHub Actions for npm and PyPI publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,58 @@
+name: Publish to npm
+
+on:
+  push:
+    tags:
+      - "node-v*" # Trigger on tags like node-v2.0.0
+
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (skip actual publish)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: nodejs
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+      - name: Publish (dry run)
+        if: inputs.dry_run == 'true'
+        run: npm publish --dry-run --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Publish
+        if: inputs.dry_run != 'true'
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-pypi.yml
+++ b/.github/workflows/publish-pypi.yml
@@ -1,0 +1,69 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "py-v*" # Trigger on tags like py-v0.1.0
+
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (upload to TestPyPI instead)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: read
+  id-token: write # Required for trusted publishing
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python
+    environment:
+      name: ${{ inputs.dry_run == 'true' && 'testpypi' || 'pypi' }}
+      url: ${{ inputs.dry_run == 'true' && 'https://test.pypi.org/p/wechatbot-sdk' || 'https://pypi.org/p/wechatbot-sdk' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install build dependencies
+        run: pip install build hatchling
+
+      - name: Install package with dev dependencies
+        run: pip install -e ".[dev]"
+
+      - name: Run tests
+        run: pytest
+
+      - name: Build package
+        run: python -m build
+
+      - name: Verify package
+        run: |
+          pip install twine
+          twine check dist/*
+
+      - name: Publish to TestPyPI (dry run)
+        if: inputs.dry_run == 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist/
+          repository-url: https://test.pypi.org/legacy/
+
+      - name: Publish to PyPI
+        if: inputs.dry_run != 'true'
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python/dist/

--- a/.pi/skills/publish/SKILL.md
+++ b/.pi/skills/publish/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: publish
+description: Publish wechatbot packages to npm and PyPI. Use when the user wants to release, publish, or deploy a new version of the Node.js or Python SDK package.
+---
+
+# Publish Packages
+
+This project has two publishable packages with separate GitHub Actions workflows:
+
+| Package | Registry | Directory | Workflow | Tag pattern |
+|---------|----------|-----------|----------|-------------|
+| `@wechatbot/wechatbot` | npm | `nodejs/` | `.github/workflows/publish-npm.yml` | `node-v*` |
+| `wechatbot-sdk` | PyPI | `python/` | `.github/workflows/publish-pypi.yml` | `py-v*` |
+
+## Pre-publish Checklist
+
+Before publishing, verify the following:
+
+1. **Version is bumped** — ensure the version in the package manifest is updated:
+   - npm: `nodejs/package.json` → `"version"` field
+   - PyPI: `python/pyproject.toml` → `[project] version` field
+2. **Tests pass** — run tests locally before tagging:
+   - npm: `cd nodejs && npm test`
+   - PyPI: `cd python && pytest`
+3. **Build succeeds** — verify the package builds cleanly:
+   - npm: `cd nodejs && npm run build`
+   - PyPI: `cd python && python -m build`
+4. **Changes are committed and pushed** to the main branch
+
+## Publishing via Git Tag
+
+Create and push a tag to trigger the GitHub Actions workflow:
+
+### Publish Node.js to npm
+
+```bash
+# 1. Bump version in nodejs/package.json
+# 2. Commit the change
+git add nodejs/package.json
+git commit -m "chore: bump node package to vX.Y.Z"
+git push
+
+# 3. Tag and push
+git tag node-vX.Y.Z
+git push origin node-vX.Y.Z
+```
+
+### Publish Python to PyPI
+
+```bash
+# 1. Bump version in python/pyproject.toml
+# 2. Commit the change
+git add python/pyproject.toml
+git commit -m "chore: bump python package to vX.Y.Z"
+git push
+
+# 3. Tag and push
+git tag py-vX.Y.Z
+git push origin py-vX.Y.Z
+```
+
+## Publishing via Manual Dispatch
+
+Both workflows support manual triggering from GitHub Actions UI with a **dry run** option:
+
+1. Go to the repo → **Actions** tab
+2. Select **Publish to npm** or **Publish to PyPI**
+3. Click **Run workflow**
+4. Optionally enable **Dry run** to test without actually publishing
+   - npm dry run: runs `npm publish --dry-run`
+   - PyPI dry run: publishes to **TestPyPI** instead of PyPI
+
+## Required Secrets & Setup
+
+### npm
+
+- Add an npm automation token as `NPM_TOKEN` in GitHub repo → Settings → Secrets and variables → Actions
+- Generate at [npmjs.com](https://www.npmjs.com/) → Access Tokens → Automation
+
+### PyPI (Trusted Publishing — no tokens needed)
+
+- Configure a trusted publisher at [pypi.org](https://pypi.org/) → Your project → Publishing
+  - Owner: GitHub username/org
+  - Repository: `wechatbot`
+  - Workflow: `publish-pypi.yml`
+  - Environment: `pypi`
+- Create GitHub environments `pypi` (and optionally `testpypi`) in repo → Settings → Environments
+
+## Publishing Both at Once
+
+To release both packages simultaneously:
+
+```bash
+# Bump both versions, commit, then tag both
+git tag node-vX.Y.Z
+git tag py-vX.Y.Z
+git push origin node-vX.Y.Z py-vX.Y.Z
+```
+
+## Troubleshooting
+
+| Issue | Solution |
+|-------|----------|
+| npm 403 Forbidden | Check `NPM_TOKEN` is valid; ensure the package name isn't taken by another user |
+| npm provenance error | Ensure `id-token: write` permission is set (already configured) |
+| PyPI auth failure | Verify trusted publisher is configured with correct workflow name and environment |
+| TestPyPI upload fails | Create `testpypi` environment in GitHub; configure trusted publisher on test.pypi.org |
+| Version conflict | The version already exists on the registry; bump the version number |


### PR DESCRIPTION
## Changes

- **`.github/workflows/publish-npm.yml`** — Publish Node.js SDK to npm
  - Triggered by `node-v*` tags or manual dispatch
  - Runs tests → build → publish with provenance
  - Supports dry run mode

- **`.github/workflows/publish-pypi.yml`** — Publish Python SDK to PyPI
  - Triggered by `py-v*` tags or manual dispatch
  - Uses trusted publishing (OIDC, no API tokens)
  - Supports dry run mode (publishes to TestPyPI)

- **`.pi/skills/publish/SKILL.md`** — Pi skill with release instructions

## Setup Required

- **npm**: Add `NPM_TOKEN` secret in repo settings
- **PyPI**: Configure trusted publisher at pypi.org with workflow `publish-pypi.yml` and environment `pypi`