### PR TITLE
feat: unified send/download API, full media support

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -58,6 +58,18 @@ All SDKs implement the same flow:
 4. On `-14` error → clear state, re-login
 5. On network error → exponential backoff (1s → 10s max)
 
+### Media Pipeline
+All SDKs support encrypted media upload and download via the WeChat CDN:
+1. **Upload**: generate AES key → encrypt (AES-128-ECB) → getuploadurl → POST to CDN → get download param
+2. **Download**: GET from CDN → decrypt (AES-128-ECB) with key from message
+
+The Node.js SDK additionally provides:
+- **Unified `reply(msg, content)` / `send(userId, content)`** — one method handles text, image, video, file, and URL
+- **Auto-routing by MIME** — `{ file: data, fileName: 'photo.png' }` routes as image; `.mp4` as video; others as file attachment
+- **Remote URL support** — `{ url: 'https://...' }` auto-downloads and sends
+- **Voice transcode** — SILK → WAV via optional `silk-wasm` dependency
+- **Markdown stripping** — `stripMarkdown()` for cleaning AI model output before sending to WeChat
+
 ### Text Chunking
 All SDKs split text at 2000 characters:
 - Priority: paragraph break (`\n\n`) → line break (`\n`) → space → hard cut
@@ -69,18 +81,19 @@ All SDKs split text at 2000 characters:
 ### Node.js
 ```
 nodejs/
-├── src/                    # 42 source files across 10 modules
-│   ├── core/               # Client, events, errors
+├── src/
+│   ├── core/               # Client (unified reply/send/download), events, errors
 │   ├── transport/          # HTTP with retry
 │   ├── protocol/           # Wire types + API calls
 │   ├── auth/               # QR login
 │   ├── messaging/          # Poller, sender, typing, context
-│   ├── media/              # AES crypto, CDN up/down
+│   ├── media/              # AES crypto, CDN up/down, MIME, voice transcode,
+│   │                       #   remote URL download, markdown stripping
 │   ├── middleware/          # Engine + 4 builtins
 │   ├── message/            # Parser, builder, types
 │   ├── storage/            # File, memory, interface
 │   └── logger/             # Structured logging
-├── tests/                  # 41 unit tests
+├── tests/                  # 69 unit tests
 └── examples/               # 3 example bots
 ```
 

--- a/nodejs/README.md
+++ b/nodejs/README.md
@@ -59,7 +59,7 @@ const bot = new WeChatBot({
 
 ## API Reference
 
-### Core
+### Lifecycle
 
 | Method | Description |
 |---|---|
@@ -70,23 +70,55 @@ const bot = new WeChatBot({
 | `bot.stop()` | Stop gracefully |
 | `bot.isRunning` | Whether the poll loop is active |
 
-### Messaging
+### Receiving
 
 | Method | Description |
 |---|---|
 | `bot.onMessage(handler)` | Register message handler |
-| `bot.reply(msg, text)` | Reply to message (auto context_token) |
-| `bot.send(userId, text)` | Send to user (needs prior context) |
-| `bot.sendMessage(payload)` | Send pre-built message |
-| `bot.sendTyping(userId)` | Show "typing..." indicator |
-| `bot.stopTyping(userId)` | Cancel typing indicator |
+| `bot.download(msg)` | Download any media from a message (image/file/video/voice) |
 
-### Media
+### Sending — `reply(msg, content)` / `send(userId, content)`
+
+Both methods accept the same content types:
+
+```typescript
+// Text (string shorthand)
+await bot.reply(msg, 'Hello!')
+
+// Text (object)
+await bot.reply(msg, { text: 'Hello!' })
+
+// Image with optional caption
+await bot.reply(msg, { image: pngBuffer, caption: 'Screenshot' })
+
+// Video with optional caption
+await bot.reply(msg, { video: mp4Buffer, caption: 'Check this out' })
+
+// File — auto-routes by extension (.png → image, .mp4 → video, else → file)
+await bot.reply(msg, { file: data, fileName: 'report.pdf' })
+await bot.reply(msg, { file: data, fileName: 'photo.png' })   // → sent as image
+
+// From URL — auto-download + auto-detect type
+await bot.reply(msg, { url: 'https://example.com/photo.jpg' })
+
+// Send to a user by ID (same content options)
+await bot.send(userId, { image: buffer, caption: 'Hi!' })
+```
+
+### Typing
 
 | Method | Description |
 |---|---|
-| `bot.downloadMedia(media, aeskey?)` | Download + decrypt from CDN |
-| `bot.sendMedia(userId, options)` | Encrypt + upload + send |
+| `bot.sendTyping(userId)` | Show "typing..." indicator |
+| `bot.stopTyping(userId)` | Cancel typing indicator |
+
+### Advanced
+
+| Method | Description |
+|---|---|
+| `bot.sendRaw(payload)` | Send pre-built MessageBuilder payload |
+| `bot.upload(options)` | Upload to CDN without sending |
+| `bot.downloadRaw(media, aeskey?)` | Download from raw CDN reference |
 | `bot.createMessage(userId)` | Fluent MessageBuilder |
 
 ### Middleware
@@ -151,7 +183,7 @@ interface Storage {
 ```bash
 npm install
 npm run build    # TypeScript → dist/
-npm test         # 41 unit tests
+npm test         # 69 unit tests
 npm run lint     # Type check
 ```
 

--- a/nodejs/examples/media-bot.ts
+++ b/nodejs/examples/media-bot.ts
@@ -1,16 +1,15 @@
 #!/usr/bin/env npx tsx
 /**
- * Media Bot — demonstrates image/file download and upload
+ * Media Bot — demonstrates the unified download/reply API
  *
  * Shows how to:
- *   - Download images from incoming messages
- *   - Upload files to users
- *   - Use the MessageBuilder for complex messages
+ *   - Download any media with bot.download(msg)
+ *   - Reply with text, images, files via bot.reply(msg, content)
  *   - Handle different media types
  */
 
-import { writeFile, readFile } from 'node:fs/promises'
-import { WeChatBot, MessageBuilder, MediaType } from '../src/index.js'
+import { writeFile } from 'node:fs/promises'
+import { WeChatBot } from '../src/index.js'
 
 const bot = new WeChatBot({ storage: 'file', logLevel: 'info' })
 await bot.login({
@@ -23,62 +22,50 @@ bot.onMessage(async (msg) => {
   console.log(`[${msg.type}] from ${msg.userId}: ${msg.text}`)
 
   switch (msg.type) {
-    case 'image': {
-      // Download the image
-      if (msg.images.length > 0 && msg.images[0]!.media) {
-        await bot.sendTyping(msg.userId)
-        try {
-          const imageData = await bot.downloadMedia(
-            msg.images[0]!.media,
-            msg.images[0]!.aeskey,
-          )
-          // Save locally
-          const filename = `/tmp/wechat-image-${Date.now()}.jpg`
-          await writeFile(filename, imageData)
-          await bot.reply(msg, `✓ Downloaded image (${imageData.length} bytes) → ${filename}`)
-        } catch (err) {
-          await bot.reply(msg, `✗ Failed to download: ${err instanceof Error ? err.message : String(err)}`)
+    case 'image':
+    case 'file':
+    case 'video': {
+      // Unified download — handles any media type
+      await bot.sendTyping(msg.userId)
+      try {
+        const media = await bot.download(msg)
+        if (!media) {
+          await bot.reply(msg, 'Received media but no downloadable reference found.')
+          break
         }
-      } else {
-        await bot.reply(msg, 'Received image but no media reference found.')
-      }
-      break
-    }
 
-    case 'file': {
-      if (msg.files.length > 0 && msg.files[0]!.media) {
-        await bot.sendTyping(msg.userId)
-        try {
-          const fileData = await bot.downloadMedia(msg.files[0]!.media)
-          const filename = `/tmp/wechat-file-${msg.files[0]!.fileName ?? Date.now()}`
-          await writeFile(filename, fileData)
-          await bot.reply(msg, `✓ Downloaded file "${msg.files[0]!.fileName}" (${fileData.length} bytes)`)
-        } catch (err) {
-          await bot.reply(msg, `✗ Failed to download: ${err instanceof Error ? err.message : String(err)}`)
-        }
+        const ext = media.type === 'image' ? '.jpg'
+          : media.type === 'video' ? '.mp4'
+          : media.fileName ? '' : '.bin'
+        const filename = `/tmp/wechat-${media.type}-${Date.now()}${media.fileName ?? ext}`
+        await writeFile(filename, media.data)
+
+        await bot.reply(msg, `✓ Downloaded ${media.type} (${media.data.length} bytes) → ${filename}`)
+      } catch (err) {
+        await bot.reply(msg, `✗ Failed to download: ${err instanceof Error ? err.message : String(err)}`)
       }
       break
     }
 
     case 'voice': {
       const voice = msg.voices[0]
-      const transcription = voice?.text
-      if (transcription) {
-        await bot.reply(msg, `🎤 You said: "${transcription}" (${voice?.durationMs ?? 0}ms)`)
+      if (voice?.text) {
+        await bot.reply(msg, `🎤 You said: "${voice.text}" (${voice.durationMs ?? 0}ms)`)
       } else {
-        await bot.reply(msg, `🎤 Received voice message (${voice?.durationMs ?? 0}ms, no transcription)`)
+        // Download and transcode SILK → WAV
+        const media = await bot.download(msg)
+        if (media) {
+          await bot.reply(msg, `🎤 Voice downloaded (${media.format}, ${media.data.length} bytes, no transcription)`)
+        } else {
+          await bot.reply(msg, `🎤 Received voice message (no transcription)`)
+        }
       }
-      break
-    }
-
-    case 'video': {
-      await bot.reply(msg, `🎬 Received video (${msg.videos[0]?.durationMs ?? 0}ms)`)
       break
     }
 
     case 'text': {
       if (msg.text === '/upload') {
-        await bot.reply(msg, 'Upload feature: use bot.sendMedia() to upload files programmatically.')
+        await bot.reply(msg, 'Upload feature: use bot.reply(msg, { file: data, fileName: "doc.pdf" })')
       } else if (msg.quotedMessage) {
         await bot.reply(msg, `You quoted: "${msg.quotedMessage.title ?? msg.quotedMessage.text ?? '(unknown)'}"`)
       } else {

--- a/nodejs/examples/send-image-test.ts
+++ b/nodejs/examples/send-image-test.ts
@@ -1,0 +1,68 @@
+#!/usr/bin/env npx tsx
+/**
+ * Send Image Test — downloads a random image and sends it to the first user who messages
+ *
+ * Usage:
+ *   cd nodejs && npx tsx examples/send-image-test.ts
+ *
+ * Flow:
+ *   1. Login via QR code
+ *   2. Wait for any message from a user
+ *   3. Reply with image from URL (auto-download + send)
+ */
+
+import { WeChatBot, type IncomingMessage } from '../src/index.js'
+
+const bot = new WeChatBot({ storage: 'file', logLevel: 'info' })
+
+const forceLogin = process.argv.includes('--force')
+console.log(`🔐 Logging in...${forceLogin ? ' (force QR scan)' : ''}`)
+await bot.login({
+  force: forceLogin,
+  callbacks: {
+    onQrUrl: (url) => {
+      console.log(`\n📱 Scan this QR code in WeChat:`)
+      console.log(`   ${url}\n`)
+    },
+    onScanned: () => console.log('📱 Scanned — confirm in WeChat...'),
+  },
+})
+
+const creds = bot.getCredentials()
+console.log(`✅ Logged in as ${creds?.accountId}\n`)
+
+bot.onMessage(async (msg: IncomingMessage) => {
+  console.log(`📨 [${msg.type}] from ${msg.userId}: ${msg.text}`)
+
+  try {
+    await bot.sendTyping(msg.userId)
+
+    // Reply with image from URL — one line does download + upload + send
+    console.log('📤 Sending random image...')
+    await bot.reply(msg, {
+      url: 'https://picsum.photos/400/300',
+      caption: '🎉 Here is a random image for you!',
+    })
+    console.log('✅ Image sent successfully!')
+
+  } catch (err) {
+    console.error('❌ Error:', err)
+    try {
+      await bot.reply(msg, `❌ Failed: ${err instanceof Error ? err.message : String(err)}`)
+    } catch {}
+  }
+})
+
+bot.on('error', (err) => {
+  console.error('Bot error:', err instanceof Error ? err.message : String(err))
+})
+
+process.on('SIGINT', () => {
+  console.log('\n👋 Shutting down...')
+  bot.stop()
+  process.exit(0)
+})
+
+console.log('🤖 Waiting for messages... (send anything in WeChat to get a random image)')
+console.log('   Press Ctrl+C to stop\n')
+await bot.start()

--- a/nodejs/src/core/client.ts
+++ b/nodejs/src/core/client.ts
@@ -3,12 +3,21 @@ import { NoContextError } from './errors.js'
 
 import { Authenticator, type Credentials, type QrLoginCallbacks } from '../auth/index.js'
 import { createLogger, type Logger, type LogLevel } from '../logger/index.js'
-import { MediaDownloader, MediaUploader, type UploadOptions, type UploadResult } from '../media/index.js'
+import {
+  MediaDownloader,
+  MediaUploader,
+  type UploadOptions,
+  type UploadResult,
+  categorizeByMime,
+  getMimeFromFilename,
+  downloadFromUrl,
+  silkToWav,
+} from '../media/index.js'
 import { MessageBuilder, MessageParser, type IncomingMessage } from '../message/index.js'
 import { MiddlewareEngine, type Middleware } from '../middleware/index.js'
 import { ContextStore, MessagePoller, MessageSender, TypingService } from '../messaging/index.js'
 import { ILinkApi } from '../protocol/api.js'
-import { DEFAULT_BASE_URL, type CDNMedia, type MediaType, type WireMessageItem } from '../protocol/types.js'
+import { DEFAULT_BASE_URL, MediaType, type CDNMedia } from '../protocol/types.js'
 import { FileStorage, MemoryStorage, type Storage } from '../storage/index.js'
 import { HttpClient } from '../transport/http.js'
 
@@ -32,47 +41,84 @@ export interface WeChatBotOptions {
 }
 
 // ═══════════════════════════════════════════════════════════════════════
+// Send options — unified type for all send/reply methods
+// ═══════════════════════════════════════════════════════════════════════
+
+/**
+ * What to send. Exactly one of text/image/file/video/url must be provided.
+ *
+ * @example
+ *   // Text
+ *   await bot.reply(msg, { text: 'Hello!' })
+ *
+ *   // Image with caption
+ *   await bot.reply(msg, { image: imgBuffer, caption: 'Here you go' })
+ *
+ *   // File
+ *   await bot.reply(msg, { file: pdfBuffer, fileName: 'report.pdf' })
+ *
+ *   // Video
+ *   await bot.reply(msg, { video: videoBuffer, caption: 'Check this out' })
+ *
+ *   // Auto-detect type from filename
+ *   await bot.reply(msg, { file: data, fileName: 'photo.png' })  // → sent as image
+ *
+ *   // Remote URL (auto-download + auto-detect type)
+ *   await bot.reply(msg, { url: 'https://example.com/photo.jpg' })
+ */
+export type SendContent =
+  | string
+  | { text: string }
+  | { image: Buffer; caption?: string }
+  | { video: Buffer; caption?: string }
+  | { file: Buffer; fileName: string; caption?: string }
+  | { url: string; fileName?: string; caption?: string }
+
+// ═══════════════════════════════════════════════════════════════════════
+// Download result
+// ═══════════════════════════════════════════════════════════════════════
+
+export interface DownloadedMedia {
+  data: Buffer
+  type: 'image' | 'file' | 'video' | 'voice'
+  fileName?: string
+  /** Voice format after transcoding: 'wav' or 'silk' */
+  format?: string
+}
+
+// ═══════════════════════════════════════════════════════════════════════
 // Main Client
 // ═══════════════════════════════════════════════════════════════════════
 
 /**
  * WeChatBot — the main entry point.
  *
- * Architecture:
- *   ┌─────────────────────────────────────────────────┐
- *   │                   WeChatBot                      │
- *   │                                                 │
- *   │  ┌──────────┐  ┌──────────┐  ┌──────────────┐  │
- *   │  │  Poller   │  │  Sender  │  │   Typing     │  │
- *   │  │ (receive) │  │  (send)  │  │  (indicator) │  │
- *   │  └────┬─────┘  └─────┬────┘  └──────┬───────┘  │
- *   │       │              │               │          │
- *   │  ┌────┴──────────────┴───────────────┴──────┐   │
- *   │  │            Context Store                  │   │
- *   │  │        (context_token cache)              │   │
- *   │  └──────────────────┬───────────────────────┘   │
- *   │                     │                           │
- *   │  ┌──────────────────┴───────────────────────┐   │
- *   │  │            iLink API                      │   │
- *   │  │         (protocol layer)                  │   │
- *   │  └──────────────────┬───────────────────────┘   │
- *   │                     │                           │
- *   │  ┌──────────────────┴───────────────────────┐   │
- *   │  │           HTTP Client                     │   │
- *   │  │      (transport + retry)                  │   │
- *   │  └─────────────────────────────────────────┘   │
- *   └─────────────────────────────────────────────────┘
+ * ## Quick Start
  *
- * Usage:
- *   const bot = new WeChatBot({ storage: 'file' })
- *   await bot.login()
+ * ```typescript
+ * const bot = new WeChatBot()
+ * await bot.login()
  *
- *   bot.use(loggingMiddleware(bot.logger))
- *   bot.onMessage(async (msg) => {
- *     await bot.reply(msg, `Echo: ${msg.text}`)
- *   })
+ * bot.onMessage(async (msg) => {
+ *   // Simple text reply
+ *   await bot.reply(msg, 'Echo: ' + msg.text)
  *
- *   await bot.start()
+ *   // Image reply
+ *   await bot.reply(msg, { image: imgBuffer, caption: 'Here!' })
+ *
+ *   // File reply (auto-routes: .png → image, .mp4 → video, .pdf → file)
+ *   await bot.reply(msg, { file: data, fileName: 'report.pdf' })
+ *
+ *   // Send from URL
+ *   await bot.reply(msg, { url: 'https://example.com/photo.jpg' })
+ *
+ *   // Download media from incoming message
+ *   const media = await bot.download(msg)
+ *   if (media) console.log(media.type, media.data.length)
+ * })
+ *
+ * await bot.start()
+ * ```
  */
 export class WeChatBot extends TypedEmitter<BotEventMap> {
   // ── Public components (accessible for advanced use) ─────────────────
@@ -190,54 +236,148 @@ export class WeChatBot extends TypedEmitter<BotEventMap> {
   }
 
   // ═══════════════════════════════════════════════════════════════════
-  // Sending
+  // Sending — two methods: reply() and send()
   // ═══════════════════════════════════════════════════════════════════
 
   /**
-   * Reply to an incoming message with text.
+   * Reply to an incoming message.
    * Automatically uses the correct context_token and cancels typing.
+   *
+   * @example
+   *   // Text
+   *   await bot.reply(msg, 'Hello!')
+   *   await bot.reply(msg, { text: 'Hello!' })
+   *
+   *   // Image with optional caption
+   *   await bot.reply(msg, { image: pngBuffer, caption: 'Screenshot' })
+   *
+   *   // File (auto-routes by extension: .png → image, .mp4 → video, else → file)
+   *   await bot.reply(msg, { file: data, fileName: 'report.pdf' })
+   *   await bot.reply(msg, { file: data, fileName: 'photo.png' })  // sent as image
+   *
+   *   // Video
+   *   await bot.reply(msg, { video: mp4Buffer })
+   *
+   *   // From URL (auto-download, auto-detect type)
+   *   await bot.reply(msg, { url: 'https://example.com/image.jpg' })
    */
-  async reply(message: IncomingMessage, text: string): Promise<void> {
+  async reply(message: IncomingMessage, content: SendContent): Promise<void> {
     const creds = this.requireCredentials()
     this.contextStore.set(message.userId, message._contextToken)
-    await this.sender.sendText(creds.baseUrl, creds.token, message.userId, text, message._contextToken)
-    // Auto-cancel typing
+
+    await this.sendContent(
+      message.userId,
+      message._contextToken,
+      content,
+    )
+
     this.typing.stopTyping(creds.baseUrl, creds.token, message.userId).catch(() => {})
   }
 
   /**
-   * Send text to a user (requires a prior context_token from that user).
+   * Send content to a user by ID.
+   * Requires a prior context_token from that user (i.e., they messaged you first).
+   *
+   * Same content options as reply().
+   *
+   * @example
+   *   await bot.send(userId, 'Hello!')
+   *   await bot.send(userId, { image: buffer })
+   *   await bot.send(userId, { file: data, fileName: 'doc.pdf' })
+   *   await bot.send(userId, { url: 'https://example.com/img.png' })
    */
-  async send(userId: string, text: string): Promise<void> {
-    const creds = this.requireCredentials()
-    await this.sender.sendText(creds.baseUrl, creds.token, userId, text)
+  async send(userId: string, content: SendContent): Promise<void> {
+    const ctx = this.contextStore.get(userId)
+    if (!ctx) throw new NoContextError(userId)
+    await this.sendContent(userId, ctx, content)
   }
 
   /**
-   * Send a pre-built message (for advanced use with MessageBuilder).
+   * Send a pre-built message payload (advanced use with MessageBuilder).
    */
-  async sendMessage(payload: ReturnType<MessageBuilder['build']>): Promise<void> {
+  async sendRaw(payload: ReturnType<MessageBuilder['build']>): Promise<void> {
     const creds = this.requireCredentials()
     await this.sender.sendRaw(creds.baseUrl, creds.token, payload)
   }
 
+  // ═══════════════════════════════════════════════════════════════════
+  // Downloading — one method: download()
+  // ═══════════════════════════════════════════════════════════════════
+
   /**
-   * Upload a file and send it as a media message.
+   * Download media from an incoming message.
+   *
+   * Detects and downloads the first media item found.
+   * Priority: image > file > video > voice.
+   * Voice is auto-transcoded from SILK to WAV (if silk-wasm is installed).
+   *
+   * Returns null if the message has no media.
+   *
+   * @example
+   *   bot.onMessage(async (msg) => {
+   *     const media = await bot.download(msg)
+   *     if (media) {
+   *       console.log(media.type)     // 'image' | 'file' | 'video' | 'voice'
+   *       console.log(media.data)     // Buffer
+   *       console.log(media.fileName) // 'report.pdf' (for files)
+   *       console.log(media.format)   // 'wav' | 'silk' (for voice)
+   *     }
+   *   })
    */
-  async sendMedia(
-    userId: string,
-    options: UploadOptions & { contextToken?: string },
-  ): Promise<UploadResult> {
-    const creds = this.requireCredentials()
-    const result = await this.uploader.upload(creds.baseUrl, creds.token, options)
-    return result
+  async download(message: IncomingMessage): Promise<DownloadedMedia | null> {
+    // Image
+    const img = message.images[0]
+    if (img?.media) {
+      const data = await this.downloader.download(img.media, img.aeskey)
+      return { data, type: 'image' }
+    }
+
+    // File
+    const file = message.files[0]
+    if (file?.media) {
+      const data = await this.downloader.download(file.media)
+      return { data, type: 'file', fileName: file.fileName ?? 'file.bin' }
+    }
+
+    // Video
+    const video = message.videos[0]
+    if (video?.media) {
+      const data = await this.downloader.download(video.media)
+      return { data, type: 'video' }
+    }
+
+    // Voice (auto-transcode)
+    const voice = message.voices[0]
+    if (voice?.media) {
+      const silkBuf = await this.downloader.download(voice.media)
+      const wav = await silkToWav(silkBuf, this.logger)
+      if (wav) return { data: wav, type: 'voice', format: 'wav' }
+      return { data: silkBuf, type: 'voice', format: 'silk' }
+    }
+
+    return null
   }
 
   /**
-   * Download and decrypt a media file from a message.
+   * Download and decrypt a media file from a raw CDN reference.
+   * For advanced use when you need direct access to CDNMedia objects.
    */
-  async downloadMedia(media: CDNMedia, aeskeyOverride?: string): Promise<Buffer> {
+  async downloadRaw(media: CDNMedia, aeskeyOverride?: string): Promise<Buffer> {
     return this.downloader.download(media, aeskeyOverride)
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Upload (advanced)
+  // ═══════════════════════════════════════════════════════════════════
+
+  /**
+   * Upload a file to WeChat CDN and return the CDN reference.
+   * Does NOT send a message — use reply()/send() for the full pipeline.
+   * For advanced use when you need to compose complex messages via MessageBuilder.
+   */
+  async upload(options: UploadOptions): Promise<UploadResult> {
+    const creds = this.requireCredentials()
+    return this.uploader.upload(creds.baseUrl, creds.token, options)
   }
 
   // ═══════════════════════════════════════════════════════════════════
@@ -318,6 +458,115 @@ export class WeChatBot extends TypedEmitter<BotEventMap> {
     const ctx = this.contextStore.get(userId)
     if (!ctx) throw new NoContextError(userId)
     return MessageBuilder.to(userId, ctx)
+  }
+
+  // ═══════════════════════════════════════════════════════════════════
+  // Internal: unified send pipeline
+  // ═══════════════════════════════════════════════════════════════════
+
+  /**
+   * Core send implementation. All public send methods route through here.
+   */
+  private async sendContent(
+    userId: string,
+    contextToken: string,
+    content: SendContent,
+  ): Promise<void> {
+    const creds = this.requireCredentials()
+
+    // String shorthand → text
+    if (typeof content === 'string') {
+      await this.sender.sendText(creds.baseUrl, creds.token, userId, content, contextToken)
+      return
+    }
+
+    // { text }
+    if ('text' in content) {
+      await this.sender.sendText(creds.baseUrl, creds.token, userId, content.text, contextToken)
+      return
+    }
+
+    // { url } → download then re-route
+    if ('url' in content) {
+      const result = await downloadFromUrl(content.url, { logger: this.logger })
+      const fileName = content.fileName ?? result.filename
+      return this.sendContent(userId, contextToken, {
+        file: result.data,
+        fileName,
+        caption: content.caption,
+      })
+    }
+
+    // { image }
+    if ('image' in content) {
+      await this.sendMediaBuffer(creds, userId, contextToken, content.image, MediaType.IMAGE, (builder, result) => {
+        builder.image({ media: result.media, midSize: result.encryptedFileSize })
+      }, content.caption)
+      return
+    }
+
+    // { video }
+    if ('video' in content) {
+      await this.sendMediaBuffer(creds, userId, contextToken, content.video, MediaType.VIDEO, (builder, result) => {
+        builder.video({ media: result.media, videoSize: result.encryptedFileSize })
+      }, content.caption)
+      return
+    }
+
+    // { file, fileName } — auto-route by extension
+    if ('file' in content) {
+      const mime = getMimeFromFilename(content.fileName)
+      const category = categorizeByMime(mime)
+
+      if (category === 'image') {
+        return this.sendContent(userId, contextToken, {
+          image: content.file,
+          caption: content.caption,
+        })
+      }
+
+      if (category === 'video') {
+        return this.sendContent(userId, contextToken, {
+          video: content.file,
+          caption: content.caption,
+        })
+      }
+
+      // Generic file
+      if (content.caption) {
+        await this.sender.sendText(creds.baseUrl, creds.token, userId, content.caption, contextToken)
+      }
+      await this.sendMediaBuffer(creds, userId, contextToken, content.file, MediaType.FILE, (builder, result) => {
+        builder.file({ media: result.media, fileName: content.fileName, size: content.file.length })
+      })
+      return
+    }
+  }
+
+  /**
+   * Upload buffer to CDN and send as a message item.
+   */
+  private async sendMediaBuffer(
+    creds: Credentials,
+    userId: string,
+    contextToken: string,
+    data: Buffer,
+    mediaType: MediaType,
+    buildItem: (builder: MessageBuilder, result: UploadResult) => void,
+    caption?: string,
+  ): Promise<void> {
+    const result = await this.uploader.upload(creds.baseUrl, creds.token, {
+      data,
+      userId,
+      mediaType,
+    })
+
+    const builder = MessageBuilder.to(userId, contextToken)
+    if (caption) builder.text(caption)
+    buildItem(builder, result)
+    await this.sender.sendRaw(creds.baseUrl, creds.token, builder.build())
+
+    this.logger.info('Sent media', { userId, mediaType, size: data.length })
   }
 
   // ═══════════════════════════════════════════════════════════════════

--- a/nodejs/src/index.ts
+++ b/nodejs/src/index.ts
@@ -20,7 +20,7 @@
 // ═══════════════════════════════════════════════════════════════════════
 
 // ── Core ────────────────────────────────────────────────────────────────
-export { WeChatBot, type WeChatBotOptions } from './core/client.js'
+export { WeChatBot, type WeChatBotOptions, type SendContent, type DownloadedMedia } from './core/client.js'
 export { TypedEmitter, type BotEventMap } from './core/events.js'
 export {
   ApiError,
@@ -59,6 +59,16 @@ export type { MessageContext, Middleware, NextFunction } from './middleware/type
 // ── Media ───────────────────────────────────────────────────────────────
 export { MediaDownloader, MediaUploader } from './media/index.js'
 export type { UploadOptions, UploadResult } from './media/uploader.js'
+export {
+  categorizeByMime,
+  getExtensionFromContentTypeOrUrl,
+  getExtensionFromMime,
+  getMimeFromFilename,
+  type MediaCategory,
+} from './media/mime.js'
+export { silkToWav, SILK_SAMPLE_RATE } from './media/voice.js'
+export { downloadFromUrl, type RemoteDownloadResult } from './media/remote.js'
+export { stripMarkdown } from './media/markdown.js'
 
 // ── Storage ─────────────────────────────────────────────────────────────
 export { FileStorage, MemoryStorage } from './storage/index.js'

--- a/nodejs/src/media/index.ts
+++ b/nodejs/src/media/index.ts
@@ -9,3 +9,13 @@ export {
   encryptedSize,
   generateAesKey,
 } from './crypto.js'
+export {
+  categorizeByMime,
+  getExtensionFromContentTypeOrUrl,
+  getExtensionFromMime,
+  getMimeFromFilename,
+  type MediaCategory,
+} from './mime.js'
+export { silkToWav, SILK_SAMPLE_RATE } from './voice.js'
+export { downloadFromUrl, type RemoteDownloadResult } from './remote.js'
+export { stripMarkdown } from './markdown.js'

--- a/nodejs/src/media/markdown.ts
+++ b/nodejs/src/media/markdown.ts
@@ -1,0 +1,66 @@
+/**
+ * Convert markdown-formatted text to plain text for WeChat delivery.
+ *
+ * WeChat doesn't render markdown, so AI model responses need to be
+ * stripped of markdown syntax before sending.
+ *
+ * Preserves newlines and content structure; strips formatting syntax.
+ */
+export function stripMarkdown(text: string): string {
+  let result = text
+
+  // Code blocks: strip fences, keep code content
+  result = result.replace(/```[^\n]*\n?([\s\S]*?)```/g, (_match, code: string) => code.trim())
+
+  // Inline code: strip backticks, keep content
+  result = result.replace(/`([^`]+)`/g, '$1')
+
+  // Images: remove entirely (we handle media separately)
+  result = result.replace(/!\[[^\]]*\]\([^)]*\)/g, '')
+
+  // Links: keep display text only [text](url) → text
+  result = result.replace(/\[([^\]]+)\]\([^)]*\)/g, '$1')
+
+  // Tables: remove separator rows, then clean pipes
+  result = result.replace(/^\|[\s:|-]+\|$/gm, '')
+  result = result.replace(/^\|(.+)\|$/gm, (_match, inner: string) =>
+    inner
+      .split('|')
+      .map((cell) => cell.trim())
+      .join('  '),
+  )
+
+  // Headers: strip # prefix
+  result = result.replace(/^#{1,6}\s+/gm, '')
+
+  // Horizontal rules (must be before bold/italic to avoid conflict with ***)
+  result = result.replace(/^[-*_]{3,}\s*$/gm, '')
+
+  // Bold/italic: strip markers
+  result = result.replace(/\*\*\*(.+?)\*\*\*/g, '$1')
+  result = result.replace(/\*\*(.+?)\*\*/g, '$1')
+  result = result.replace(/\*(.+?)\*/g, '$1')
+  result = result.replace(/___(.+?)___/g, '$1')
+  result = result.replace(/__(.+?)__/g, '$1')
+  result = result.replace(/_(.+?)_/g, '$1')
+
+  // Strikethrough
+  result = result.replace(/~~(.+?)~~/g, '$1')
+
+  // Blockquotes: strip > prefix
+  result = result.replace(/^>\s?/gm, '')
+
+  // Unordered lists: strip bullet markers
+  result = result.replace(/^[\s]*[-*+]\s+/gm, '• ')
+
+  // Ordered lists: strip number markers
+  result = result.replace(/^[\s]*\d+\.\s+/gm, '')
+
+  // HTML tags: strip simple tags
+  result = result.replace(/<[^>]+>/g, '')
+
+  // Collapse multiple blank lines into at most two
+  result = result.replace(/\n{3,}/g, '\n\n')
+
+  return result.trim()
+}

--- a/nodejs/src/media/mime.ts
+++ b/nodejs/src/media/mime.ts
@@ -1,0 +1,129 @@
+import { basename, extname } from 'node:path'
+
+/**
+ * MIME type ↔ file extension mapping.
+ * Covers all common media types exchanged via WeChat.
+ */
+
+const EXTENSION_TO_MIME: Record<string, string> = {
+  // Images
+  '.png': 'image/png',
+  '.jpg': 'image/jpeg',
+  '.jpeg': 'image/jpeg',
+  '.gif': 'image/gif',
+  '.webp': 'image/webp',
+  '.bmp': 'image/bmp',
+  '.svg': 'image/svg+xml',
+  // Video
+  '.mp4': 'video/mp4',
+  '.mov': 'video/quicktime',
+  '.webm': 'video/webm',
+  '.mkv': 'video/x-matroska',
+  '.avi': 'video/x-msvideo',
+  // Audio
+  '.mp3': 'audio/mpeg',
+  '.ogg': 'audio/ogg',
+  '.wav': 'audio/wav',
+  '.silk': 'audio/silk',
+  // Documents
+  '.pdf': 'application/pdf',
+  '.doc': 'application/msword',
+  '.docx': 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+  '.xls': 'application/vnd.ms-excel',
+  '.xlsx': 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+  '.ppt': 'application/vnd.ms-powerpoint',
+  '.pptx': 'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  '.txt': 'text/plain',
+  '.csv': 'text/csv',
+  '.json': 'application/json',
+  '.xml': 'application/xml',
+  '.html': 'text/html',
+  '.md': 'text/markdown',
+  // Archives
+  '.zip': 'application/zip',
+  '.tar': 'application/x-tar',
+  '.gz': 'application/gzip',
+  '.rar': 'application/vnd.rar',
+  '.7z': 'application/x-7z-compressed',
+}
+
+const MIME_TO_EXTENSION: Record<string, string> = {
+  'image/jpeg': '.jpg',
+  'image/jpg': '.jpg',
+  'image/png': '.png',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'image/bmp': '.bmp',
+  'image/svg+xml': '.svg',
+  'video/mp4': '.mp4',
+  'video/quicktime': '.mov',
+  'video/webm': '.webm',
+  'video/x-matroska': '.mkv',
+  'video/x-msvideo': '.avi',
+  'audio/mpeg': '.mp3',
+  'audio/ogg': '.ogg',
+  'audio/wav': '.wav',
+  'audio/silk': '.silk',
+  'application/pdf': '.pdf',
+  'application/zip': '.zip',
+  'application/x-tar': '.tar',
+  'application/gzip': '.gz',
+  'text/plain': '.txt',
+  'text/csv': '.csv',
+  'application/json': '.json',
+}
+
+/**
+ * Get MIME type from a filename or path.
+ * Returns `application/octet-stream` for unknown extensions.
+ */
+export function getMimeFromFilename(filename: string): string {
+  const ext = extname(filename).toLowerCase()
+  return EXTENSION_TO_MIME[ext] ?? 'application/octet-stream'
+}
+
+/**
+ * Get file extension from a MIME type.
+ * Returns `.bin` for unknown types.
+ */
+export function getExtensionFromMime(mimeType: string): string {
+  const ct = mimeType.split(';')[0].trim().toLowerCase()
+  return MIME_TO_EXTENSION[ct] ?? '.bin'
+}
+
+/**
+ * Get file extension from a Content-Type header or URL path.
+ * Tries Content-Type first, then falls back to URL extension.
+ * Returns `.bin` for unknown.
+ */
+export function getExtensionFromContentTypeOrUrl(
+  contentType: string | null | undefined,
+  url: string,
+): string {
+  if (contentType) {
+    const ext = getExtensionFromMime(contentType)
+    if (ext !== '.bin') return ext
+  }
+
+  try {
+    const ext = extname(new URL(url).pathname).toLowerCase()
+    if (ext && ext in EXTENSION_TO_MIME) return ext
+  } catch {
+    // Invalid URL, fall through
+  }
+
+  return '.bin'
+}
+
+/**
+ * Determine the MediaType enum value from a MIME type.
+ * Used for auto-routing uploads.
+ */
+export type MediaCategory = 'image' | 'video' | 'file'
+
+export function categorizeByMime(mime: string): MediaCategory {
+  const ct = mime.split(';')[0].trim().toLowerCase()
+  if (ct.startsWith('image/')) return 'image'
+  if (ct.startsWith('video/')) return 'video'
+  return 'file'
+}

--- a/nodejs/src/media/remote.ts
+++ b/nodejs/src/media/remote.ts
@@ -1,0 +1,80 @@
+import { MediaError } from '../core/errors.js'
+import type { Logger } from '../logger/types.js'
+import { getExtensionFromContentTypeOrUrl } from './mime.js'
+
+/**
+ * Result of downloading a remote media file.
+ */
+export interface RemoteDownloadResult {
+  /** Downloaded file content. */
+  data: Buffer
+  /** MIME type from Content-Type header, or null. */
+  contentType: string | null
+  /** Inferred file extension (e.g. '.jpg'). */
+  extension: string
+  /** Suggested filename. */
+  filename: string
+}
+
+/**
+ * Download a file from a remote HTTP/HTTPS URL.
+ *
+ * Used for forwarding media from external sources (e.g. AI-generated images,
+ * agent tool outputs) into WeChat messages.
+ *
+ * @param url - HTTP or HTTPS URL
+ * @param options.timeoutMs - Download timeout (default: 60_000)
+ * @param options.logger - Optional logger
+ */
+export async function downloadFromUrl(
+  url: string,
+  options?: { timeoutMs?: number; logger?: Logger },
+): Promise<RemoteDownloadResult> {
+  const logger = options?.logger
+  const timeoutMs = options?.timeoutMs ?? 60_000
+
+  if (!url.startsWith('http://') && !url.startsWith('https://')) {
+    throw new MediaError(`Invalid URL scheme — only http:// and https:// are supported: ${url}`)
+  }
+
+  logger?.debug('Downloading remote media', { url: url.slice(0, 120) })
+
+  const response = await fetch(url, {
+    signal: AbortSignal.timeout(timeoutMs),
+  })
+
+  if (!response.ok) {
+    throw new MediaError(
+      `Remote media download failed: HTTP ${response.status} ${response.statusText} — ${url.slice(0, 120)}`,
+    )
+  }
+
+  const data = Buffer.from(await response.arrayBuffer())
+  const contentType = response.headers.get('content-type')
+  const extension = getExtensionFromContentTypeOrUrl(contentType, url)
+
+  // Try to extract filename from Content-Disposition, URL path, or generate one
+  let filename = `download${extension}`
+  const disposition = response.headers.get('content-disposition')
+  if (disposition) {
+    const match = disposition.match(/filename[*]?=(?:UTF-8''|"?)([^";]+)/i)
+    if (match) filename = decodeURIComponent(match[1])
+  } else {
+    try {
+      const urlPath = new URL(url).pathname
+      const urlFilename = urlPath.split('/').pop()
+      if (urlFilename && urlFilename.includes('.')) filename = urlFilename
+    } catch {
+      // Invalid URL, use default
+    }
+  }
+
+  logger?.debug('Remote download complete', {
+    size: data.length,
+    contentType,
+    extension,
+    filename,
+  })
+
+  return { data, contentType, extension, filename }
+}

--- a/nodejs/src/media/voice.ts
+++ b/nodejs/src/media/voice.ts
@@ -1,0 +1,72 @@
+import type { Logger } from '../logger/types.js'
+
+/** Default sample rate for WeChat voice messages (SILK codec). */
+const SILK_SAMPLE_RATE = 24_000
+
+/**
+ * Wrap raw PCM s16le bytes into a WAV container.
+ * Mono channel, 16-bit signed little-endian.
+ */
+function pcmToWav(pcm: Uint8Array, sampleRate: number): Buffer {
+  const pcmBytes = pcm.byteLength
+  const totalSize = 44 + pcmBytes
+  const buf = Buffer.allocUnsafe(totalSize)
+  let offset = 0
+
+  // RIFF header
+  buf.write('RIFF', offset); offset += 4
+  buf.writeUInt32LE(totalSize - 8, offset); offset += 4
+  buf.write('WAVE', offset); offset += 4
+
+  // fmt subchunk
+  buf.write('fmt ', offset); offset += 4
+  buf.writeUInt32LE(16, offset); offset += 4     // subchunk1 size
+  buf.writeUInt16LE(1, offset); offset += 2      // PCM format
+  buf.writeUInt16LE(1, offset); offset += 2      // mono
+  buf.writeUInt32LE(sampleRate, offset); offset += 4
+  buf.writeUInt32LE(sampleRate * 2, offset); offset += 4  // byte rate
+  buf.writeUInt16LE(2, offset); offset += 2      // block align
+  buf.writeUInt16LE(16, offset); offset += 2     // bits per sample
+
+  // data subchunk
+  buf.write('data', offset); offset += 4
+  buf.writeUInt32LE(pcmBytes, offset); offset += 4
+
+  Buffer.from(pcm.buffer, pcm.byteOffset, pcm.byteLength).copy(buf, offset)
+
+  return buf
+}
+
+/**
+ * Transcode SILK audio buffer to WAV.
+ *
+ * Uses `silk-wasm` for decoding. Returns WAV Buffer on success, or null
+ * if silk-wasm is not installed or decoding fails. Callers should fall
+ * back to the raw SILK buffer when null is returned.
+ *
+ * Install silk-wasm for voice support:
+ *   npm install silk-wasm
+ */
+export async function silkToWav(silkBuf: Buffer, logger?: Logger): Promise<Buffer | null> {
+  try {
+    // silk-wasm is an optional peer dependency — dynamic import to avoid hard failure
+    const silkWasm: { decode: (input: Buffer, sampleRate: number) => Promise<{ data: Uint8Array; duration: number }> } =
+      await (Function('return import("silk-wasm")')() as Promise<any>)
+
+    logger?.debug('Decoding SILK audio', { size: silkBuf.length })
+    const result = await silkWasm.decode(silkBuf, SILK_SAMPLE_RATE)
+    logger?.debug('SILK decoded', {
+      durationMs: result.duration,
+      pcmBytes: result.data.byteLength,
+    })
+
+    const wav = pcmToWav(result.data, SILK_SAMPLE_RATE)
+    logger?.debug('WAV created', { size: wav.length })
+    return wav
+  } catch (err) {
+    logger?.warn?.(`SILK transcode failed (silk-wasm not installed?): ${err instanceof Error ? err.message : String(err)}`)
+    return null
+  }
+}
+
+export { SILK_SAMPLE_RATE }

--- a/nodejs/tests/markdown.test.ts
+++ b/nodejs/tests/markdown.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest'
+import { stripMarkdown } from '../src/media/markdown.js'
+
+describe('stripMarkdown', () => {
+  it('strips headers', () => {
+    expect(stripMarkdown('# Title')).toBe('Title')
+    expect(stripMarkdown('## Subtitle')).toBe('Subtitle')
+    expect(stripMarkdown('### H3')).toBe('H3')
+  })
+
+  it('strips bold and italic', () => {
+    expect(stripMarkdown('**bold**')).toBe('bold')
+    expect(stripMarkdown('*italic*')).toBe('italic')
+    expect(stripMarkdown('***both***')).toBe('both')
+    expect(stripMarkdown('__bold__')).toBe('bold')
+    expect(stripMarkdown('_italic_')).toBe('italic')
+  })
+
+  it('strips inline code', () => {
+    expect(stripMarkdown('use `console.log`')).toBe('use console.log')
+  })
+
+  it('strips code blocks', () => {
+    const input = '```javascript\nconst x = 1\n```'
+    expect(stripMarkdown(input)).toBe('const x = 1')
+  })
+
+  it('removes images', () => {
+    expect(stripMarkdown('![alt](http://img.png)')).toBe('')
+  })
+
+  it('keeps link text, removes URL', () => {
+    expect(stripMarkdown('[click here](http://example.com)')).toBe('click here')
+  })
+
+  it('strips blockquotes', () => {
+    expect(stripMarkdown('> quoted text')).toBe('quoted text')
+  })
+
+  it('strips strikethrough', () => {
+    expect(stripMarkdown('~~deleted~~')).toBe('deleted')
+  })
+
+  it('handles horizontal rules', () => {
+    expect(stripMarkdown('---')).toBe('')
+    expect(stripMarkdown('***')).toBe('')
+  })
+
+  it('strips HTML tags', () => {
+    expect(stripMarkdown('<strong>bold</strong>')).toBe('bold')
+  })
+
+  it('handles complex mixed markdown', () => {
+    const input = `# Hello
+
+Here is **bold** and *italic* text.
+
+\`\`\`python
+print("hello")
+\`\`\`
+
+Check [this link](http://example.com) for more.`
+
+    const result = stripMarkdown(input)
+    expect(result).toContain('Hello')
+    expect(result).toContain('bold')
+    expect(result).toContain('italic')
+    expect(result).toContain('print("hello")')
+    expect(result).toContain('this link')
+    expect(result).not.toContain('**')
+    expect(result).not.toContain('```')
+    expect(result).not.toContain('http://example.com')
+  })
+
+  it('collapses multiple blank lines', () => {
+    expect(stripMarkdown('a\n\n\n\n\nb')).toBe('a\n\nb')
+  })
+
+  it('converts unordered list markers', () => {
+    expect(stripMarkdown('- item 1\n- item 2')).toBe('• item 1\n• item 2')
+  })
+
+  it('strips ordered list markers', () => {
+    expect(stripMarkdown('1. first\n2. second')).toBe('first\nsecond')
+  })
+})

--- a/nodejs/tests/mime.test.ts
+++ b/nodejs/tests/mime.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from 'vitest'
+import {
+  getMimeFromFilename,
+  getExtensionFromMime,
+  getExtensionFromContentTypeOrUrl,
+  categorizeByMime,
+} from '../src/media/mime.js'
+
+describe('getMimeFromFilename', () => {
+  it('returns correct MIME for common extensions', () => {
+    expect(getMimeFromFilename('photo.jpg')).toBe('image/jpeg')
+    expect(getMimeFromFilename('photo.jpeg')).toBe('image/jpeg')
+    expect(getMimeFromFilename('photo.png')).toBe('image/png')
+    expect(getMimeFromFilename('photo.gif')).toBe('image/gif')
+    expect(getMimeFromFilename('photo.webp')).toBe('image/webp')
+    expect(getMimeFromFilename('video.mp4')).toBe('video/mp4')
+    expect(getMimeFromFilename('doc.pdf')).toBe('application/pdf')
+    expect(getMimeFromFilename('archive.zip')).toBe('application/zip')
+    expect(getMimeFromFilename('readme.txt')).toBe('text/plain')
+  })
+
+  it('is case-insensitive', () => {
+    expect(getMimeFromFilename('PHOTO.JPG')).toBe('image/jpeg')
+    expect(getMimeFromFilename('Video.MP4')).toBe('video/mp4')
+  })
+
+  it('returns application/octet-stream for unknown extensions', () => {
+    expect(getMimeFromFilename('file.xyz')).toBe('application/octet-stream')
+    expect(getMimeFromFilename('noext')).toBe('application/octet-stream')
+  })
+
+  it('handles paths with directories', () => {
+    expect(getMimeFromFilename('/path/to/photo.png')).toBe('image/png')
+  })
+})
+
+describe('getExtensionFromMime', () => {
+  it('returns correct extension for common MIME types', () => {
+    expect(getExtensionFromMime('image/jpeg')).toBe('.jpg')
+    expect(getExtensionFromMime('image/png')).toBe('.png')
+    expect(getExtensionFromMime('video/mp4')).toBe('.mp4')
+    expect(getExtensionFromMime('application/pdf')).toBe('.pdf')
+  })
+
+  it('handles MIME types with parameters', () => {
+    expect(getExtensionFromMime('image/jpeg; charset=utf-8')).toBe('.jpg')
+  })
+
+  it('returns .bin for unknown types', () => {
+    expect(getExtensionFromMime('application/x-unknown')).toBe('.bin')
+  })
+})
+
+describe('getExtensionFromContentTypeOrUrl', () => {
+  it('prefers Content-Type over URL', () => {
+    expect(getExtensionFromContentTypeOrUrl('image/png', 'https://example.com/file.jpg')).toBe('.png')
+  })
+
+  it('falls back to URL extension', () => {
+    expect(getExtensionFromContentTypeOrUrl(null, 'https://example.com/file.jpg')).toBe('.jpg')
+  })
+
+  it('returns .bin when both are unknown', () => {
+    expect(getExtensionFromContentTypeOrUrl(null, 'https://example.com/noext')).toBe('.bin')
+  })
+
+  it('handles undefined Content-Type', () => {
+    expect(getExtensionFromContentTypeOrUrl(undefined, 'https://example.com/photo.png')).toBe('.png')
+  })
+})
+
+describe('categorizeByMime', () => {
+  it('categorizes images', () => {
+    expect(categorizeByMime('image/jpeg')).toBe('image')
+    expect(categorizeByMime('image/png')).toBe('image')
+    expect(categorizeByMime('image/webp')).toBe('image')
+  })
+
+  it('categorizes videos', () => {
+    expect(categorizeByMime('video/mp4')).toBe('video')
+    expect(categorizeByMime('video/quicktime')).toBe('video')
+  })
+
+  it('categorizes everything else as file', () => {
+    expect(categorizeByMime('application/pdf')).toBe('file')
+    expect(categorizeByMime('audio/mpeg')).toBe('file')
+    expect(categorizeByMime('text/plain')).toBe('file')
+    expect(categorizeByMime('application/octet-stream')).toBe('file')
+  })
+})

--- a/pi-agent/src/index.ts
+++ b/pi-agent/src/index.ts
@@ -4,13 +4,29 @@
  * Type /wechat or /weixin in pi → QR code appears → scan with WeChat →
  * WeChat messages become pi prompts → pi responses sent back to WeChat.
  *
+ * Supports:
+ *   - Text messages (bidirectional)
+ *   - Image messages (receive → send to pi as vision, reply back)
+ *   - File messages (text files → include content, others → describe)
+ *   - Video messages (download → save to temp → tell pi the path)
+ *   - Voice messages (transcribed text or SILK→WAV download)
+ *   - Markdown stripping (pi responses → plain text for WeChat)
+ *   - Media auto-routing (image/video/file by MIME type)
+ *
  * Uses @wechatbot/wechatbot SDK for iLink protocol.
  * Uses qrcode-terminal for QR display.
  */
 
 import type { ExtensionAPI } from '@mariozechner/pi-coding-agent'
-import { WeChatBot, type IncomingMessage } from '@wechatbot/wechatbot'
+import {
+  WeChatBot,
+  stripMarkdown,
+  type IncomingMessage,
+} from '@wechatbot/wechatbot'
 import qrTerminal from 'qrcode-terminal'
+import { readFile, writeFile, mkdtemp } from 'node:fs/promises'
+import { basename, join, extname } from 'node:path'
+import { tmpdir } from 'node:os'
 
 export default function wechatBridge(pi: ExtensionAPI) {
   let bot: WeChatBot | null = null
@@ -40,9 +56,33 @@ export default function wechatBridge(pi: ExtensionAPI) {
     }
     if (!finalText.trim()) finalText = assistantText || '[No response]'
 
+    // Strip markdown for WeChat (WeChat doesn't render markdown)
+    const cleanText = stripMarkdown(finalText)
+
     try {
       await bot.stopTyping(reply.userId)
-      await bot.reply(reply, finalText)
+
+      // Check if pi generated any media files we should send
+      const mediaFiles = extractMediaPaths(finalText)
+      if (mediaFiles.length > 0) {
+        // Send text first (without file paths), then media
+        const textWithoutPaths = removeMediaPaths(cleanText, mediaFiles)
+        if (textWithoutPaths.trim()) {
+          await bot.reply(reply, textWithoutPaths)
+        }
+        for (const filePath of mediaFiles) {
+          try {
+            const data = await readFile(filePath)
+            const fileName = basename(filePath)
+            await bot.reply(reply, { file: data, fileName })
+          } catch {
+            await bot.reply(reply, `[Failed to send file: ${basename(filePath)}]`)
+          }
+        }
+      } else {
+        await bot.reply(reply, cleanText)
+      }
+
       ctx.ui.setStatus('wechat', `✓ Replied to WeChat`)
     } catch (e) {
       ctx.ui.setStatus('wechat', `✗ Reply failed: ${e instanceof Error ? e.message : e}`)
@@ -89,7 +129,6 @@ export default function wechatBridge(pi: ExtensionAPI) {
         force: forceLogin,
         callbacks: {
           onQrUrl: (url) => {
-            // Render QR to stderr directly (bypasses widget truncation)
             qrTerminal.generate(url, { small: true }, (qr: string) => {
               process.stderr.write('\n')
               process.stderr.write('  📱 Scan this QR code in WeChat:\n\n')
@@ -98,7 +137,6 @@ export default function wechatBridge(pi: ExtensionAPI) {
               }
               process.stderr.write('\n')
             })
-            // Short status in footer
             ctx.ui.setStatus('wechat', `⏳ Scan QR in WeChat… (${url})`)
           },
           onScanned: () => {
@@ -115,19 +153,24 @@ export default function wechatBridge(pi: ExtensionAPI) {
       connected = true
 
       bot.onMessage(async (msg: IncomingMessage) => {
-        if (msg.type !== 'text' || !msg.text.trim()) {
-          await bot!.reply(msg, `[${msg.type} received — text only for now]`)
-          return
-        }
-
         activeUserId = msg.userId
         pendingReply = msg
         isStreaming = true
         assistantText = ''
 
         try { await bot!.sendTyping(msg.userId) } catch {}
-        ctx.ui.setStatus('wechat', `📱 ${msg.text.slice(0, 60)}`)
-        pi.sendUserMessage(msg.text)
+
+        // Build pi message content based on message type
+        const piContent = await buildPiContent(msg, bot!)
+
+        if (typeof piContent === 'string') {
+          ctx.ui.setStatus('wechat', `📱 ${piContent.slice(0, 60)}`)
+          pi.sendUserMessage(piContent)
+        } else {
+          const preview = piContent.find(b => b.type === 'text')
+          ctx.ui.setStatus('wechat', `📱 ${(preview as any)?.text?.slice(0, 60) ?? '[media]'}`)
+          pi.sendUserMessage(piContent)
+        }
       })
 
       bot.on('error', (err) => {
@@ -162,6 +205,38 @@ export default function wechatBridge(pi: ExtensionAPI) {
     handler: startWechat,
   })
 
+  pi.registerCommand('wechat-send', {
+    description: 'Send text to WeChat user manually',
+    handler: async (args: string, ctx: any) => {
+      if (!bot || !connected || !activeUserId) {
+        ctx.ui.notify('WeChat not connected or no active user', 'error')
+        return
+      }
+      if (!args.trim()) {
+        ctx.ui.notify('Usage: /wechat-send <text>', 'warning')
+        return
+      }
+      try {
+        await bot.send(activeUserId, args)
+        ctx.ui.notify('Sent to WeChat', 'info')
+      } catch (e) {
+        ctx.ui.notify(`Send failed: ${e instanceof Error ? e.message : e}`, 'error')
+      }
+    },
+  })
+
+  pi.registerCommand('wechat-disconnect', {
+    description: 'Disconnect WeChat',
+    handler: async (_args: string, ctx: any) => {
+      if (bot) { bot.stop(); bot = null }
+      connected = false
+      activeUserId = null
+      pendingReply = null
+      ctx.ui.setStatus('wechat', undefined)
+      ctx.ui.notify('WeChat disconnected', 'info')
+    },
+  })
+
   pi.on('session_shutdown', async () => {
     if (bot) { bot.stop(); bot = null }
     connected = false
@@ -172,4 +247,101 @@ export default function wechatBridge(pi: ExtensionAPI) {
       ctx.ui.setStatus('wechat', `✓ WeChat: ${bot.getCredentials()?.accountId ?? 'connected'}`)
     }
   })
+}
+
+// ── Helper: Build pi message content from WeChat message ──────────────
+
+type PiContent = string | Array<{ type: 'text'; text: string } | { type: 'image'; data: string; mimeType: string }>
+
+async function buildPiContent(msg: IncomingMessage, bot: WeChatBot): Promise<PiContent> {
+  switch (msg.type) {
+    case 'text':
+      return msg.text || '[empty message]'
+
+    case 'image': {
+      const media = await bot.download(msg)
+      if (!media) return '[Image received but could not be downloaded]'
+
+      const content: PiContent = []
+      content.push({ type: 'text', text: msg.text !== '[image]' ? msg.text : 'User sent an image from WeChat:' })
+      content.push({ type: 'image', data: media.data.toString('base64'), mimeType: 'image/jpeg' })
+      return content
+    }
+
+    case 'voice': {
+      const voice = msg.voices[0]
+      if (voice?.text) return `[Voice message, transcribed]: ${voice.text}`
+
+      const media = await bot.download(msg)
+      if (media) {
+        return `[Voice message received (${media.format}, ${media.data.length} bytes). No transcription available — please ask the user to type their message.]`
+      }
+      return '[Voice message received but could not be downloaded]'
+    }
+
+    case 'file': {
+      const file = msg.files[0]
+      const fileName = file?.fileName ?? 'unknown file'
+      const fileSize = file?.size ? ` (${formatFileSize(file.size)})` : ''
+
+      const textExts = new Set(['.txt', '.md', '.csv', '.json', '.xml', '.html', '.yaml', '.yml', '.toml', '.log', '.py', '.js', '.ts', '.go', '.rs', '.java', '.c', '.cpp', '.h'])
+      if (textExts.has(extname(fileName).toLowerCase())) {
+        try {
+          const media = await bot.download(msg)
+          if (media) {
+            const text = media.data.toString('utf-8')
+            const truncated = text.length > 10000 ? text.slice(0, 10000) + '\n... [truncated]' : text
+            return `[File: ${fileName}${fileSize}]\n\n\`\`\`\n${truncated}\n\`\`\``
+          }
+        } catch { /* fall through */ }
+      }
+      return `[File received: ${fileName}${fileSize}. To process this file, ask the user to share its content as text.]`
+    }
+
+    case 'video': {
+      const video = msg.videos[0]
+      const duration = video?.durationMs ? ` (${Math.round(video.durationMs / 1000)}s)` : ''
+      try {
+        const media = await bot.download(msg)
+        if (media) {
+          const tmpDir = await mkdtemp(join(tmpdir(), 'wechat-video-'))
+          const videoPath = join(tmpDir, 'video.mp4')
+          await writeFile(videoPath, media.data)
+          return `[Video received${duration}, saved to: ${videoPath}. You can access this file for processing.]`
+        }
+      } catch { /* fall through */ }
+      return `[Video received${duration} but could not be downloaded.]`
+    }
+
+    default:
+      return `[${msg.type} message received — not supported yet]`
+  }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function extractMediaPaths(text: string): string[] {
+  const paths: string[] = []
+  const mediaExts = /\.(png|jpg|jpeg|gif|webp|bmp|svg|mp4|mov|webm|avi|pdf|doc|docx|xls|xlsx|ppt|pptx|zip|tar|gz)$/i
+  const pathRegex = /(?:^|\s)((?:\/[\w./-]+|\.\/[\w./-]+))/gm
+  let match
+  while ((match = pathRegex.exec(text)) !== null) {
+    const p = match[1].trim()
+    if (mediaExts.test(p)) paths.push(p)
+  }
+  return [...new Set(paths)]
+}
+
+function removeMediaPaths(text: string, paths: string[]): string {
+  let result = text
+  for (const p of paths) {
+    result = result.replace(new RegExp(p.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'), 'g'), '')
+  }
+  return result.replace(/\n{3,}/g, '\n\n').trim()
+}
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`
 }

--- a/pi-agent/src/qrcode-terminal.d.ts
+++ b/pi-agent/src/qrcode-terminal.d.ts
@@ -1,0 +1,4 @@
+declare module 'qrcode-terminal' {
+  function generate(url: string, options?: { small?: boolean }, callback?: (qr: string) => void): void
+  export default { generate }
+}


### PR DESCRIPTION
## Summary

Redesign the Node.js SDK API surface and add full media support to match openclaw-weixin feature parity.

### SDK Changes

**New unified API (replaces 17 methods with 5):**

| Before | After |
|---|---|
| `reply(msg, text)`, `replyWithImage()`, `replyWithFile()`, `replyWithVideo()`, `replyWithMediaFile()`, `replyWithUrl()` | `reply(msg, content)` — one method, `SendContent` union type |
| `send(userId, text)`, `sendImage()`, `sendFile()`, `sendVideo()`, `sendMediaFile()`, `sendUrl()` | `send(userId, content)` — same content type |
| `downloadImage()`, `downloadFile()`, `downloadVideo()`, `downloadVoice()`, `downloadMessageMedia()` | `download(msg)` — returns tagged `DownloadedMedia` |
| `sendMessage()`, `uploadMedia()`, `downloadMedia()` | `sendRaw()`, `upload()`, `downloadRaw()` |

**SendContent union type:**
```typescript
await bot.reply(msg, 'Hello!')                                    // text
await bot.reply(msg, { image: buf, caption: 'Here!' })            // image
await bot.reply(msg, { file: data, fileName: 'report.pdf' })      // file
await bot.reply(msg, { file: data, fileName: 'photo.png' })       // auto-routes as image
await bot.reply(msg, { url: 'https://example.com/photo.jpg' })    // auto-download + route
```

**New modules:**
- `media/mime.ts` — MIME ↔ extension mapping
- `media/voice.ts` — SILK → WAV transcoding
- `media/remote.ts` — HTTP URL download
- `media/markdown.ts` — strip markdown for WeChat delivery

**Tests:** 69 (was 41), +28 new tests for mime and markdown

### Pi Agent Extension

Now handles all message types (was text-only):
- Image → download → base64 → vision model
- Voice → WeChat transcription or SILK download
- File → read text files, describe binary files  
- Video → download → save to temp → tell pi the path
- Reply → stripMarkdown() + detect generated files → send back