### PR TITLE
fix(ci): use npm install instead of npm ci

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -37,7 +37,7 @@ jobs:
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
-        run: npm ci
+        run: npm install
 
       - name: Run tests
         run: npm test


### PR DESCRIPTION
package-lock.json is gitignored, so npm ci fails. Use npm install instead.