### PR TITLE
ci: switch npm publish to Trusted Publishing (OIDC)

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -47,12 +47,8 @@ jobs:
 
       - name: Publish (dry run)
         if: inputs.dry_run == 'true'
-        run: npm publish --dry-run --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --dry-run --access public --provenance
 
       - name: Publish
         if: inputs.dry_run != 'true'
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- 移除 NPM_TOKEN 依赖
- 使用 OIDC Trusted Publishing 发布 npm 包
- 更安全，无需长期 token