### PR TITLE
fix(ci): restore NODE_AUTH_TOKEN for npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -48,7 +48,11 @@ jobs:
       - name: Publish (dry run)
         if: inputs.dry_run == 'true'
         run: npm publish --dry-run --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish
         if: inputs.dry_run != 'true'
         run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
Trusted Publishing OIDC returns 404 without token. Use Automation token (bypasses 2FA).