### PR TITLE
fix(ci): proper Trusted Publishing OIDC for npm

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          registry-url: "https://registry.npmjs.org"
+          # NOTE: no registry-url here — let npm use OIDC Trusted Publishing
 
       - name: Install dependencies
         run: npm install
@@ -47,12 +47,8 @@ jobs:
 
       - name: Publish (dry run)
         if: inputs.dry_run == 'true'
-        run: npm publish --dry-run --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --dry-run --access public --provenance --registry https://registry.npmjs.org
 
       - name: Publish
         if: inputs.dry_run != 'true'
-        run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --provenance --registry https://registry.npmjs.org


### PR DESCRIPTION
Remove registry-url from setup-node so npm can use OIDC token. No NPM_TOKEN needed.