### PR TITLE
fix(ci): use Granular Access Token for npm publish

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 22
-          # NOTE: no registry-url here — let npm use OIDC Trusted Publishing
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: npm install
@@ -47,8 +47,12 @@ jobs:
 
       - name: Publish (dry run)
         if: inputs.dry_run == 'true'
-        run: npm publish --dry-run --access public --provenance --registry https://registry.npmjs.org
+        run: npm publish --dry-run --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish
         if: inputs.dry_run != 'true'
-        run: npm publish --access public --provenance --registry https://registry.npmjs.org
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
npm Trusted Publishing OIDC requires newer npm cli support. Use Granular Access Token with bypass 2FA for now.