### PR TITLE
fix(ci): switch to true OIDC Trusted Publishing

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -36,6 +36,9 @@ jobs:
           node-version: 22
           registry-url: "https://registry.npmjs.org"
 
+      - name: Upgrade npm (OIDC requires >= 11.5.1)
+        run: npm install -g npm@latest
+
       - name: Install dependencies
         run: npm install
 
@@ -48,11 +51,7 @@ jobs:
       - name: Publish (dry run)
         if: inputs.dry_run == 'true'
         run: npm publish --dry-run --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish
         if: inputs.dry_run != 'true'
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -25,6 +25,10 @@
     "dist",
     "README.md"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/corespeed-io/wechatbot.git"
+  },
   "license": "MIT",
   "devDependencies": {
     "@types/node": "^22.0.0",


### PR DESCRIPTION
## Summary
- Remove `NODE_AUTH_TOKEN` env vars that override OIDC authentication (even an empty value prevents npm from using OIDC)
- Add `npm install -g npm@latest` step — OIDC requires npm >= 11.5.1, but Node 22 ships with npm ~10.x
- Add `repository` field to `package.json` for provenance attestation

## Context
npm Trusted Publishing (OIDC) is truly token-free — no `NPM_TOKEN` secret needed. The previous workflow failed because `NODE_AUTH_TOKEN` was set, which overrides OIDC, and npm was too old to support OIDC anyway.

## Test plan
- [ ] Merge and trigger `workflow_dispatch` with `dry_run=true` to verify OIDC auth works
- [ ] Then publish for real with a version bump or tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)