### PR TITLE
chore: prepare pi-agent for npm publishing

### DIFF
--- a/.github/workflows/publish-pi-agent.yml
+++ b/.github/workflows/publish-pi-agent.yml
@@ -1,0 +1,51 @@
+name: Publish pi-agent to npm
+
+on:
+  push:
+    tags:
+      - "pi-agent-v*" # Trigger on tags like pi-agent-v0.1.0
+
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (skip actual publish)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: pi-agent
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Upgrade npm (OIDC requires >= 11.5.1)
+        run: npm install -g npm@latest
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Publish (dry run)
+        if: inputs.dry_run == 'true'
+        run: npm publish --dry-run --access public --provenance
+
+      - name: Publish
+        if: inputs.dry_run != 'true'
+        run: npm publish --access public --provenance

--- a/.pi/skills/publish/SKILL.md
+++ b/.pi/skills/publish/SKILL.md
@@ -10,6 +10,7 @@ This project has two publishable packages with separate GitHub Actions workflows
 | Package | Registry | Directory | Workflow | Tag pattern |
 |---------|----------|-----------|----------|-------------|
 | `@wechatbot/wechatbot` | npm | `nodejs/` | `.github/workflows/publish-npm.yml` | `node-v*` |
+| `@wechatbot/pi-agent` | npm | `pi-agent/` | `.github/workflows/publish-pi-agent.yml` | `pi-agent-v*` |
 | `wechatbot-sdk` | PyPI | `python/` | `.github/workflows/publish-pypi.yml` | `py-v*` |
 
 ## Pre-publish Checklist
@@ -70,21 +71,69 @@ Both workflows support manual triggering from GitHub Actions UI with a **dry run
    - npm dry run: runs `npm publish --dry-run`
    - PyPI dry run: publishes to **TestPyPI** instead of PyPI
 
-## Required Secrets & Setup
+## First-Time Publishing (New Package)
 
-### npm
+OIDC Trusted Publishing **cannot** be used for the very first publish of a package — the package must already exist on the registry. Follow these steps for initial setup:
 
-- Add an npm automation token as `NPM_TOKEN` in GitHub repo → Settings → Secrets and variables → Actions
-- Generate at [npmjs.com](https://www.npmjs.com/) → Access Tokens → Automation
+### npm — First Publish
 
-### PyPI (Trusted Publishing — no tokens needed)
+1. **Create an npm account** at [npmjs.com](https://www.npmjs.com/) if you don't have one
+2. **Login locally**: `npm login`
+3. **Publish manually** from the package directory:
+   ```bash
+   cd nodejs
+   npm publish --access public
+   ```
+4. After the first version is live, configure Trusted Publishing (see below) for all subsequent releases
 
-- Configure a trusted publisher at [pypi.org](https://pypi.org/) → Your project → Publishing
-  - Owner: GitHub username/org
-  - Repository: `wechatbot`
-  - Workflow: `publish-pypi.yml`
-  - Environment: `pypi`
-- Create GitHub environments `pypi` (and optionally `testpypi`) in repo → Settings → Environments
+### PyPI — First Publish
+
+Option A — **Pending trusted publisher** (recommended, no token needed):
+
+1. Go to [pypi.org](https://pypi.org/) → log in → **Publishing** → **Add a pending publisher**
+2. Fill in: package name (`wechatbot-sdk`), owner (`corespeed-io`), repo (`wechatbot`), workflow (`publish-pypi.yml`), environment (`pypi`)
+3. Trigger the GitHub Actions workflow — PyPI will accept the first publish via OIDC
+
+Option B — Manual publish:
+
+1. Create a PyPI account and generate an API token at [pypi.org](https://pypi.org/) → Account settings → API tokens
+2. Publish locally:
+   ```bash
+   cd python
+   python -m build
+   twine upload dist/*
+   ```
+3. After the first version is live, configure Trusted Publishing (see below)
+
+## Configuring Trusted Publishing (OIDC)
+
+Both npm and PyPI use OIDC Trusted Publishing — GitHub Actions exchanges a short-lived OIDC token with the registry, so **no long-lived secrets are needed**.
+
+### npm — Configure Trusted Publisher
+
+1. Go to [npmjs.com](https://www.npmjs.com/) → log in → click your package (`@wechatbot/wechatbot`)
+2. **Settings** → **Trusted Publishers** → **Add a trusted publisher**
+3. Fill in:
+   - Repository owner: `corespeed-io`
+   - Repository name: `wechatbot`
+   - Workflow filename: `publish-npm.yml`
+4. Click **Add**
+5. Workflow requirements:
+   - `permissions: id-token: write` must be set in the workflow
+   - npm >= 11.5.1 (the workflow upgrades automatically since Node 22 ships with ~10.x)
+   - Do **NOT** set `NODE_AUTH_TOKEN` env var — it overrides OIDC
+   - `package.json` must have a `repository` field matching the GitHub repo
+
+### PyPI — Configure Trusted Publisher
+
+1. Go to [pypi.org](https://pypi.org/) → log in → your project (`wechatbot-sdk`) → **Publishing**
+2. **Add a new publisher**:
+   - Owner: `corespeed-io`
+   - Repository: `wechatbot`
+   - Workflow: `publish-pypi.yml`
+   - Environment: `pypi`
+3. Click **Add**
+4. In GitHub repo → **Settings** → **Environments**, create environments `pypi` (and optionally `testpypi`)
 
 ## Publishing Both at Once
 
@@ -97,12 +146,60 @@ git tag py-vX.Y.Z
 git push origin node-vX.Y.Z py-vX.Y.Z
 ```
 
+## Go Module Publishing (Future Reference)
+
+Go modules don't use a central registry with upload — they are published by **pushing a git tag**. The Go module proxy (`proxy.golang.org`) automatically fetches from GitHub.
+
+1. Ensure `go.mod` exists in the module directory with the correct `module` path (e.g. `module github.com/corespeed-io/wechatbot/go`)
+2. Bump version by tagging:
+   ```bash
+   # If the module is in repo root:
+   git tag vX.Y.Z
+
+   # If the module is in a subdirectory (e.g. go/):
+   git tag go/vX.Y.Z
+   ```
+3. Push the tag: `git push origin go/vX.Y.Z`
+4. The Go proxy picks it up automatically — no CI workflow, no tokens, no Trusted Publishing needed
+5. Verify: `go list -m github.com/corespeed-io/wechatbot/go@vX.Y.Z`
+
+> For major versions v2+, the module path must include the major version suffix (e.g. `module github.com/corespeed-io/wechatbot/go/v2`).
+
+## Rust Crate Publishing (Future Reference)
+
+Rust crates are published to [crates.io](https://crates.io/). Unlike npm/PyPI, crates.io does **not** support OIDC Trusted Publishing — a token is required.
+
+### First Publish
+
+1. Create an account at [crates.io](https://crates.io/) (login via GitHub)
+2. Generate an API token: crates.io → Account Settings → API Tokens
+3. Login locally: `cargo login <token>`
+4. Publish:
+   ```bash
+   cd rust
+   cargo publish
+   ```
+
+### CI Publishing
+
+1. Add the crates.io API token as `CARGO_REGISTRY_TOKEN` in GitHub repo → Settings → Secrets
+2. Example workflow step:
+   ```yaml
+   - name: Publish to crates.io
+     run: cargo publish
+     env:
+       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+   ```
+
+> **Note:** `cargo publish` does a full build and runs tests before uploading. Ensure `Cargo.toml` has `version`, `license`, `description`, and `repository` fields — crates.io requires them.
+
 ## Troubleshooting
 
 | Issue | Solution |
 |-------|----------|
-| npm 403 Forbidden | Check `NPM_TOKEN` is valid; ensure the package name isn't taken by another user |
-| npm provenance error | Ensure `id-token: write` permission is set (already configured) |
+| npm 403 Forbidden | Verify trusted publisher is configured on npmjs.com with correct repo/workflow |
+| npm ENEEDAUTH / 404 | Ensure `NODE_AUTH_TOKEN` is NOT set (it overrides OIDC); ensure npm >= 11.5.1 |
+| npm provenance error | Ensure `id-token: write` permission is set and `repository` field exists in `package.json` |
 | PyPI auth failure | Verify trusted publisher is configured with correct workflow name and environment |
 | TestPyPI upload fails | Create `testpypi` environment in GitHub; configure trusted publisher on test.pypi.org |
 | Version conflict | The version already exists on the registry; bump the version number |

--- a/pi-agent/package.json
+++ b/pi-agent/package.json
@@ -4,11 +4,22 @@
   "description": "Pi extension — type /wechat, scan QR code, chat with Pi from WeChat",
   "type": "module",
   "keywords": ["pi-package"],
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/corespeed-io/wechatbot.git",
+    "directory": "pi-agent"
+  },
+  "files": [
+    "src",
+    "README.md",
+    "package.json"
+  ],
   "pi": {
     "extensions": ["./src/index.ts"]
   },
   "dependencies": {
-    "@wechatbot/wechatbot": "file:../nodejs",
+    "@wechatbot/wechatbot": "^2.0.1",
     "qrcode-terminal": "^0.12.0"
   },
   "peerDependencies": {

--- a/pi-agent/src/index.ts
+++ b/pi-agent/src/index.ts
@@ -200,38 +200,6 @@ export default function wechatBridge(pi: ExtensionAPI) {
     handler: startWechat,
   })
 
-  pi.registerCommand('wechat-send', {
-    description: 'Send text to WeChat user manually',
-    handler: async (args: string, ctx: any) => {
-      if (!bot || !connected || !activeUserId) {
-        ctx.ui.notify('WeChat not connected or no active user', 'error')
-        return
-      }
-      if (!args.trim()) {
-        ctx.ui.notify('Usage: /wechat-send <text>', 'warning')
-        return
-      }
-      try {
-        await bot.send(activeUserId, args)
-        ctx.ui.notify('Sent to WeChat', 'info')
-      } catch (e) {
-        ctx.ui.notify(`Send failed: ${e instanceof Error ? e.message : e}`, 'error')
-      }
-    },
-  })
-
-  pi.registerCommand('wechat-disconnect', {
-    description: 'Disconnect WeChat',
-    handler: async (_args: string, ctx: any) => {
-      if (bot) { bot.stop(); bot = null }
-      connected = false
-      activeUserId = null
-      pendingReply = null
-      ctx.ui.setStatus('wechat', undefined)
-      ctx.ui.notify('WeChat disconnected', 'info')
-    },
-  })
-
   pi.on('session_shutdown', async () => {
     if (bot) { bot.stop(); bot = null }
     connected = false


### PR DESCRIPTION
- Update `pi-agent/package.json`: change `@wechatbot/wechatbot` from `file:../nodejs` to `^2.0.1` (npm), add `repository`, `license`, `files` fields
- Add `.github/workflows/publish-pi-agent.yml` for CI publishing via `pi-agent-v*` tags
- Update publish skill docs