### PR TITLE
fix: use correct Go module path github.com/corespeed-io/wechatbot/golang

### DIFF
--- a/README.EN.MD
+++ b/README.EN.MD
@@ -23,7 +23,7 @@ Connect any agent to WeChat in 5 minutes. Inspired by [openclaw-weixin-cli](http
 |-----|---------|--------|
 | [Node.js](nodejs/) | `npm install @wechatbot/wechatbot` | ✅ Production Ready |
 | [Python](python/) | `pip install wechatbot-sdk` | ✅ Production Ready |
-| [Go](golang/) | `go get github.com/corespeed-io/wechatbot-go` | ✅ Production Ready |
+| [Go](golang/) | `go get github.com/corespeed-io/wechatbot/golang` | ✅ Production Ready |
 | [Rust](rust/) | `cargo add wechatbot` | ✅ Production Ready |
 
 ## ⚡ Quick Start

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 |-----|------|------|
 | [Node.js](nodejs/) | `npm install @wechatbot/wechatbot` | ✅ 生产就绪 |
 | [Python](python/) | `pip install wechatbot-sdk` | ✅ 生产就绪 |
-| [Go](golang/) | `go get github.com/corespeed-io/wechatbot-go` | ✅ 生产就绪 |
+| [Go](golang/) | `go get github.com/corespeed-io/wechatbot/golang` | ✅ 生产就绪 |
 | [Rust](rust/) | `cargo add wechatbot` | ✅ 生产就绪 |
 
 ## ⚡ 快速开始

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -25,7 +25,7 @@ graph TD
 
 | Feature | Node.js | Go | Rust |
 |---|---|---|---|
-| Package | `@wechatbot/wechatbot` | `github.com/corespeed-io/wechatbot-go` | `wechatbot` (crates.io) |
+| Package | `@wechatbot/wechatbot` | `github.com/corespeed-io/wechatbot/golang` | `wechatbot` (crates.io) |
 | Async model | `async/await` (Promises) | goroutines + `context.Context` | `async/await` (tokio) |
 | Middleware | ✓ Express-style pipeline | — (use handler composition) | — (use closures) |
 | Storage | Pluggable (file/memory/custom) | File-based | File-based |

--- a/golang/README.md
+++ b/golang/README.md
@@ -5,7 +5,7 @@ WeChat iLink Bot SDK for Go — simple, concurrent, production-ready.
 ## Install
 
 ```bash
-go get github.com/corespeed-io/wechatbot-go
+go get github.com/corespeed-io/wechatbot/golang
 ```
 
 Requires Go 1.22+. Zero CGO dependencies.
@@ -18,7 +18,7 @@ package main
 import (
     "context"
     "fmt"
-    wechatbot "github.com/corespeed-io/wechatbot-go"
+    wechatbot "github.com/corespeed-io/wechatbot/golang"
 )
 
 func main() {

--- a/golang/bot.go
+++ b/golang/bot.go
@@ -10,8 +10,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/corespeed-io/wechatbot-go/internal/auth"
-	"github.com/corespeed-io/wechatbot-go/internal/protocol"
+	"github.com/corespeed-io/wechatbot/golang/internal/auth"
+	"github.com/corespeed-io/wechatbot/golang/internal/protocol"
 )
 
 // MessageHandler is called for each incoming user message.

--- a/golang/examples/echo-bot/main.go
+++ b/golang/examples/echo-bot/main.go
@@ -8,7 +8,7 @@ import (
 	"os/signal"
 	"syscall"
 
-	wechatbot "github.com/corespeed-io/wechatbot-go"
+	wechatbot "github.com/corespeed-io/wechatbot/golang"
 )
 
 func main() {

--- a/golang/go.mod
+++ b/golang/go.mod
@@ -1,3 +1,3 @@
-module github.com/corespeed-io/wechatbot-go
+module github.com/corespeed-io/wechatbot/golang
 
 go 1.22

--- a/golang/internal/auth/login.go
+++ b/golang/internal/auth/login.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/corespeed-io/wechatbot-go/internal/protocol"
+	"github.com/corespeed-io/wechatbot/golang/internal/protocol"
 )
 
 // Credentials holds bot authentication data.


### PR DESCRIPTION
The separate repo `corespeed-io/wechatbot-go` doesn't exist. The Go SDK lives in this monorepo's `golang/` subdirectory.

Updated 9 references across:
- `golang/go.mod`
- `golang/bot.go`, `golang/internal/auth/login.go`, `golang/examples/echo-bot/main.go`
- `golang/README.md`, `README.md`, `README.EN.MD`, `docs/architecture.md`