### PR TITLE
feat(pi-agent): inject system prompt for WeChat bridge awareness

### DIFF
--- a/pi-agent/package.json
+++ b/pi-agent/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wechatbot/pi-agent",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Pi extension — type /wechat, scan QR code, chat with Pi from WeChat",
   "type": "module",
   "keywords": ["pi-package"],

--- a/pi-agent/src/index.ts
+++ b/pi-agent/src/index.ts
@@ -36,6 +36,27 @@ export default function wechatBridge(pi: ExtensionAPI) {
   let assistantText = ''
   let isStreaming = false
 
+  // ── Inject system prompt so agent knows about WeChat bridge ────────
+
+  pi.on('before_agent_start', async (event) => {
+    if (!connected || !bot || !pendingReply) return
+
+    return {
+      systemPrompt: event.systemPrompt + `\n
+## WeChat Bridge (Active)
+
+You are currently bridged to WeChat via the wechatbot extension.
+A real WeChat user is chatting with you — your response will be sent back to them.
+
+Key behaviors:
+- **No markdown**: WeChat doesn't render markdown. Write plain text. Use line breaks for structure.
+- **Send files**: To send a file (image, video, document) back to WeChat, mention its absolute path in your response (e.g. /tmp/photo.png). The bridge auto-detects paths ending in media extensions and sends them as attachments.
+- **Concise replies**: WeChat is a mobile chat app. Keep responses short and conversational.
+- **Media received**: Images arrive as vision input. Videos/voice/files are described with metadata.
+`,
+    }
+  })
+
   // ── Capture pi response → send back to WeChat ────────────────────
 
   pi.on('agent_end', async (event, ctx) => {


### PR DESCRIPTION
## What

Add `before_agent_start` handler to inject WeChat context into the system prompt when a WeChat user is actively chatting.

## Why

Previously the agent had **no explicit knowledge** that its responses go to WeChat. It would write markdown, give verbose answers, and didn't know it could send files by mentioning paths. The extension relied on implicit signals (status bar, message prefixes) that the agent couldn't reliably interpret.

## Changes

- **`before_agent_start` hook** — appends a `## WeChat Bridge (Active)` section to the system prompt
- **Conditional** — only injects when `connected && pendingReply`, so normal pi usage is unaffected
- **Instructions** — tells the agent: no markdown, mention file paths to send attachments, keep replies concise
- **Version bump** — `0.1.0` → `0.1.1`

## Publish

After merge, tag `pi-agent-v0.1.1` to trigger npm publish via GitHub Actions.