### PR TITLE
docs: add Media API reference to Python, Go, and Rust READMEs

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -119,6 +119,37 @@ err := bot.SendTyping(ctx, userID)
 err := bot.StopTyping(ctx, userID)
 ```
 
+### Media Operations
+
+```go
+// Reply with media content
+bot.ReplyContent(ctx, msg, wechatbot.SendImage(pngBytes))
+bot.ReplyContent(ctx, msg, wechatbot.SendFile(data, "report.pdf"))
+bot.ReplyContent(ctx, msg, wechatbot.SendVideo(mp4Bytes))
+
+// Send media proactively (needs prior context_token)
+bot.SendMedia(ctx, userID, wechatbot.SendImage(pngBytes))
+```
+
+```go
+// Download media from incoming message (priority: image > file > video > voice)
+media, err := bot.Download(ctx, msg)
+if err == nil && media != nil {
+    fmt.Printf("Type: %s, Size: %d bytes\n", media.Type, len(media.Data))
+    if media.FileName != "" {
+        fmt.Printf("Filename: %s\n", media.FileName)
+    }
+}
+
+// Download a raw CDN reference directly
+raw, err := bot.DownloadRaw(ctx, msg.Images[0].Media, msg.Images[0].AESKey)
+```
+
+```go
+// Upload to CDN without sending a message
+result, err := bot.Upload(ctx, fileBytes, userID, 3)
+```
+
 ### Lifecycle
 
 ```go

--- a/python/README.md
+++ b/python/README.md
@@ -70,6 +70,53 @@ bot = WeChatBot(
 | `await bot.send(user_id, text)` | Send to user (needs prior context) |
 | `await bot.send_typing(user_id)` | Show "typing..." indicator |
 | `await bot.stop_typing(user_id)` | Cancel typing indicator |
+| `await bot.reply_media(msg, content)` | Reply with media (image, file, video) |
+| `await bot.send_media(user_id, content)` | Send media to user (needs prior context) |
+| `await bot.download(msg)` | Download media from incoming message |
+| `await bot.download_raw(media, aeskey)` | Download and decrypt a raw CDN media reference |
+| `await bot.upload(data, user_id, media_type)` | Upload file to CDN (does not send) |
+
+## Media Operations
+
+### Sending Media
+
+```python
+# Reply with an image
+await bot.reply_media(msg, {"image": png_bytes})
+
+# Reply with a file
+await bot.reply_media(msg, {"file": data, "file_name": "report.pdf"})
+
+# Reply with a video
+await bot.reply_media(msg, {"video": mp4_bytes, "caption": "Check this"})
+
+# Send media proactively (needs prior context_token)
+await bot.send_media(user_id, {"image": png_bytes})
+```
+
+### Downloading Media
+
+```python
+@bot.on_message
+async def handle(msg):
+    # Auto-detect and download (priority: image > file > video > voice)
+    media = await bot.download(msg)
+    if media:
+        print(f"Type: {media.type}, Size: {len(media.data)} bytes")
+        if media.file_name:
+            print(f"Filename: {media.file_name}")
+
+    # Or download a raw CDN reference directly
+    if msg.images:
+        raw = await bot.download_raw(msg.images[0].media, msg.images[0].aes_key)
+```
+
+### Uploading to CDN
+
+```python
+# Upload without sending — returns UploadResult with CDN metadata
+result = await bot.upload(file_bytes, user_id, media_type=3)
+```
 
 ## Message Types
 

--- a/rust/README.md
+++ b/rust/README.md
@@ -121,6 +121,33 @@ bot.send(user_id, "Hello").await?;
 bot.send_typing(user_id).await?;
 ```
 
+### Media Operations
+
+```rust
+// Reply with media content
+bot.reply_media(&msg, SendContent::Image(png_bytes)).await?;
+bot.reply_media(&msg, SendContent::File { data, file_name: "report.pdf".into() }).await?;
+bot.reply_media(&msg, SendContent::Video(mp4_bytes)).await?;
+```
+
+```rust
+// Download media from incoming message (priority: image > file > video > voice)
+if let Some(media) = bot.download(&msg).await? {
+    println!("Type: {}, Size: {} bytes", media.media_type, media.data.len());
+    if let Some(name) = &media.file_name {
+        println!("Filename: {}", name);
+    }
+}
+
+// Download a raw CDN reference directly
+let raw = bot.download_raw(&msg.images[0].media.as_ref().unwrap(), None).await?;
+```
+
+```rust
+// Upload to CDN without sending a message
+let result = bot.upload(&file_bytes, user_id, 3).await?;
+```
+
 ### Lifecycle
 
 ```rust


### PR DESCRIPTION
## Summary
- Add **Media Operations** section to Python, Go, and Rust SDK READMEs
- Document `download()`, `download_raw()`, `upload()`, `reply_media()` / `ReplyContent()` / `SendMedia()` methods
- Add code examples for sending media, downloading media, and uploading to CDN

These methods were already implemented in all three SDKs but missing from their README documentation.

## Test plan
- [ ] Verify code examples match actual SDK method signatures
- [ ] Confirm README renders correctly on GitHub

🤖 Generated with [Claude Code](https://claude.com/claude-code)