### PR TITLE
fix(rust): add serde(default) to GetUpdatesResponse.ret

### DIFF
--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -60,6 +60,7 @@ pub struct QrStatusResponse {
 /// Get updates response.
 #[derive(Debug, Deserialize)]
 pub struct GetUpdatesResponse {
+    #[serde(default)]
     pub ret: i32,
     #[serde(default)]
     pub msgs: Vec<WireMessage>,


### PR DESCRIPTION
## Summary
- Add `#[serde(default)]` to `GetUpdatesResponse.ret` field in Rust SDK
- Server may omit the `ret` field, causing silent deserialization failure and preventing message reception
- Follow-up fix from @daomu's feedback in #44

## Test plan
- [x] `cargo check` passes
- [ ] Verify getupdates works when server omits `ret` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)