### PR TITLE
ci: add crates.io publish workflow

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -1,0 +1,59 @@
+name: Publish to crates.io
+
+on:
+  push:
+    tags:
+      - "rust-v*" # Trigger on tags like rust-v0.2.0
+
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Dry run (skip actual publish)"
+        required: false
+        default: "false"
+        type: choice
+        options:
+          - "false"
+          - "true"
+
+permissions:
+  contents: read
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: rust
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Rust
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo registry
+        uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: rust
+
+      - name: Build
+        run: cargo build --release
+
+      - name: Run tests
+        run: cargo test
+
+      - name: Package (verify)
+        run: cargo package --allow-dirty
+
+      - name: Publish (dry run)
+        if: inputs.dry_run == 'true'
+        run: cargo publish --dry-run --allow-dirty
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+      - name: Publish
+        if: inputs.dry_run != 'true'
+        run: cargo publish
+        env:
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/publish-crate.yml` to automate publishing the Rust SDK to crates.io
- Triggered on `rust-v*` tags (e.g. `rust-v0.2.0`), matching the existing npm/pypi/pi-agent publish patterns
- Also supports manual `workflow_dispatch` with an optional `dry_run` input

## Motivation
Fixes #52 — the Rust SDK version was bumped to `0.2.0` in #46 but never published to crates.io because no publish pipeline existed.

## Required secret
Repository must have `CARGO_REGISTRY_TOKEN` configured (scope: `publish-update`, restricted to crate `wechatbot`).

## Test plan
- [ ] Merge PR
- [ ] Configure `CARGO_REGISTRY_TOKEN` in repo secrets
- [ ] Run workflow manually with `dry_run=true` to verify CI env
- [ ] Tag `rust-v0.2.0` and push to trigger real publish
- [ ] Verify `0.2.0` appears on https://crates.io/crates/wechatbot/versions

🤖 Generated with [Claude Code](https://claude.com/claude-code)