### PR TITLE
chore(rust): bump rand from 0.8 to 0.10 and fix deprecations

### DIFF
--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
  "cfg-if",
  "cipher",
- "cpufeatures",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
@@ -75,6 +75,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "chacha20"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.0",
+ "rand_core",
+]
+
+[[package]]
 name = "cipher"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -115,6 +126,15 @@ name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
@@ -313,6 +333,7 @@ dependencies = [
  "cfg-if",
  "libc",
  "r-efi",
+ "rand_core",
  "wasip2",
  "wasip3",
 ]
@@ -862,15 +883,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -906,33 +918,20 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "d2e8e8bcc7961af1fdac401278c6a831614941f6164ee3bf4ce61b7edb162207"
 dependencies = [
- "libc",
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
-dependencies = [
- "ppv-lite86",
+ "chacha20",
+ "getrandom 0.4.2",
  "rand_core",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.6.4"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
-dependencies = [
- "getrandom 0.2.17",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -2040,26 +2039,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efbb2a062be311f2ba113ce66f697a4dc589f85e78a4aea276200804cea0ed87"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.47"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e8bc7269b54418e7aeeef514aa68f8690b8c0489a06b0136e5f57c4c5ccab89"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,7 +14,7 @@ aes = "0.8"
 base64 = "0.22"
 hex = "0.4"
 md-5 = "0.10"
-rand = "0.8"
+rand = "0.10"
 reqwest = { version = "0.12", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/rust/src/bot.rs
+++ b/rust/src/bot.rs
@@ -12,7 +12,7 @@ use crate::error::{Result, WeChatBotError};
 use crate::protocol::{self, ILinkClient};
 use crate::types::*;
 use md5::{Md5, Digest};
-use rand::RngCore;
+use rand::Rng;
 use serde_json::json;
 
 /// Message handler callback type.
@@ -423,7 +423,7 @@ impl WeChatBot {
         let ciphertext = crypto::encrypt_aes_ecb(data, &aes_key);
 
         let mut filekey_buf = [0u8; 16];
-        rand::thread_rng().fill_bytes(&mut filekey_buf);
+        rand::rng().fill_bytes(&mut filekey_buf);
         let filekey = hex::encode(filekey_buf);
 
         let raw_md5 = hex::encode(Md5::digest(data));

--- a/rust/src/crypto.rs
+++ b/rust/src/crypto.rs
@@ -3,7 +3,7 @@
 use aes::cipher::{BlockDecrypt, BlockEncrypt, KeyInit};
 use aes::Aes128;
 use base64::Engine;
-use rand::RngCore;
+use rand::Rng;
 
 use crate::error::{Result, WeChatBotError};
 
@@ -36,7 +36,7 @@ pub fn decrypt_aes_ecb(ciphertext: &[u8], key: &[u8; 16]) -> Result<Vec<u8>> {
 /// Generate a random 16-byte AES key.
 pub fn generate_aes_key() -> [u8; 16] {
     let mut key = [0u8; 16];
-    rand::thread_rng().fill_bytes(&mut key);
+    rand::rng().fill_bytes(&mut key);
     key
 }
 

--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -1,7 +1,7 @@
 //! Raw iLink Bot API HTTP calls.
 
 use base64::Engine;
-use rand::RngCore;
+use rand::Rng;
 use reqwest::Client;
 use serde::Deserialize;
 use serde_json::{json, Value};
@@ -33,7 +33,7 @@ fn build_client_version() -> String {
 /// Generate the X-WECHAT-UIN header value.
 pub fn random_wechat_uin() -> String {
     let mut buf = [0u8; 4];
-    rand::thread_rng().fill_bytes(&mut buf);
+    rand::rng().fill_bytes(&mut buf);
     let val = u32::from_be_bytes(buf);
     base64::engine::general_purpose::STANDARD.encode(val.to_string())
 }


### PR DESCRIPTION
## Summary
- Upgrades `rand` to the latest stable **0.10.1** (supersedes #54 which only bumped to 0.9.3)
- Fixes deprecation warnings by adapting to the new API

## API changes in this PR
| Old (rand 0.8) | New (rand 0.10) |
|---|---|
| `rand::thread_rng()` | `rand::rng()` |
| `use rand::RngCore` | `use rand::Rng` |

Affected files: `rust/src/crypto.rs`, `rust/src/protocol.rs`, `rust/src/bot.rs`

## Why 0.10 instead of 0.9.3?
- 0.10.1 is the current stable; rand 0.9 is already on its way out
- Staying on 0.9 leaves 3 deprecation warnings per build (`rand::thread_rng` renamed to `rng`)
- Both 0.9 → 0.10 require adapting `RngCore` imports anyway, so combining into one upgrade is cleaner

## Test plan
- [x] `cargo build` — no warnings, no errors
- [x] `cargo test` — 43 passed, 0 failed
- [ ] CI (Ubuntu / macOS / Windows) passes

## Supersedes
Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)