### PR TITLE
fix(all): detect session expiry when API returns errcode without ret

### DIFF
--- a/golang/internal/protocol/api.go
+++ b/golang/internal/protocol/api.go
@@ -175,14 +175,14 @@ func (c *Client) apiPost(ctx context.Context, baseURL, endpoint, token string, b
 		return nil, &APIError{Message: string(raw), HTTPStatus: resp.StatusCode}
 	}
 
-	// Check ret != 0
+	// Check ret != 0 or errcode != 0
 	var check struct {
 		Ret     int    `json:"ret"`
 		ErrCode int    `json:"errcode"`
 		ErrMsg  string `json:"errmsg"`
 	}
 	json.Unmarshal(raw, &check)
-	if check.Ret != 0 {
+	if check.Ret != 0 || check.ErrCode != 0 {
 		code := check.ErrCode
 		if code == 0 {
 			code = check.Ret

--- a/nodejs/src/transport/http.ts
+++ b/nodejs/src/transport/http.ts
@@ -137,14 +137,15 @@ export class HttpClient {
       })
     }
 
-    // Check iLink business-level errors (ret !== 0)
-    if (typeof (data as { ret?: number }).ret === 'number' && (data as { ret: number }).ret !== 0) {
-      const ret = (data as { ret: number }).ret
-      const errcode = (data as { errcode?: number }).errcode ?? ret
-      const errmsg = (data as { errmsg?: string }).errmsg ?? `API error ret=${ret}`
+    // Check iLink business-level errors (ret !== 0 or errcode !== 0)
+    const ret = (data as { ret?: number }).ret
+    const errcode = (data as { errcode?: number }).errcode
+    if ((typeof ret === 'number' && ret !== 0) || (typeof errcode === 'number' && errcode !== 0)) {
+      const code = errcode ?? ret ?? 0
+      const errmsg = (data as { errmsg?: string }).errmsg ?? `API error ret=${ret} errcode=${errcode}`
       throw new ApiError(errmsg, {
         httpStatus: response.status,
-        errcode,
+        errcode: code,
         payload: data,
       })
     }

--- a/python/wechatbot/protocol.py
+++ b/python/wechatbot/protocol.py
@@ -85,9 +85,10 @@ async def _parse_response(resp: aiohttp.ClientResponse, label: str) -> dict[str,
         )
 
     ret = payload.get("ret")
-    if isinstance(ret, int) and ret != 0:
-        code = payload.get("errcode", ret)
-        msg = payload.get("errmsg") or f"{label} failed (ret={ret})"
+    errcode = payload.get("errcode")
+    if (isinstance(ret, int) and ret != 0) or (isinstance(errcode, int) and errcode != 0):
+        code = errcode if isinstance(errcode, int) and errcode != 0 else (ret or 0)
+        msg = payload.get("errmsg") or f"{label} failed (ret={ret} errcode={errcode})"
         raise ApiError(msg, http_status=resp.status, errcode=code, payload=payload)
 
     return payload

--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -134,7 +134,7 @@ impl ILinkClient {
             .api_post(base_url, "/ilink/bot/getupdates", token, &body, 45)
             .await?;
         let result: GetUpdatesResponse = serde_json::from_value(resp)?;
-        if result.ret != 0 {
+        if result.ret != 0 || result.errcode.is_some_and(|c| c != 0) {
             let code = result.errcode.unwrap_or(result.ret);
             let msg = result
                 .errmsg


### PR DESCRIPTION
## Summary
- Fix session-expired detection across **all four SDKs** (Rust, Node.js, Python, Go)
- When the server kicks a session (user logs in on another device), API returns `{ "errcode": -14, "errmsg": "session expired" }` **without** a `ret` field
- All SDKs only checked `ret != 0`, which silently passed because the missing `ret` defaults to `0` / `undefined` / `None`
- Bot's poll loop would spin infinitely without detecting the disconnect

## Changes
| SDK | File | Fix |
|---|---|---|
| Rust | `rust/src/protocol.rs` | `ret != 0 \|\| errcode.is_some_and(\|c\| c != 0)` |
| Node.js | `nodejs/src/transport/http.ts` | Check both `ret` and `errcode` in unified condition |
| Python | `python/wechatbot/protocol.py` | Check both `ret` and `errcode` with `isinstance` guards |
| Go | `golang/internal/protocol/api.go` | `check.Ret != 0 \|\| check.ErrCode != 0` |

## Test plan
- [x] Rust: 46 tests pass
- [x] Node.js: 69 tests pass
- [x] Python: 22 tests pass
- [x] Go: all tests pass

Fixes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)