### PR TITLE
chore: release patch versions for errcode fix

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wechatbot/wechatbot",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "WeChat iLink Bot SDK — modular, extensible, production-grade",
   "type": "module",
   "exports": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wechatbot-sdk"
-version = "0.2.0"
+version = "0.2.1"
 description = "WeChat iLink Bot SDK for Python — async, typed, production-grade"
 readme = "README.md"
 license = { text = "MIT" }

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wechatbot"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "WeChat iLink Bot SDK for Rust"
 license = "MIT"


### PR DESCRIPTION
## Summary
- Rust: `0.3.0` → `0.3.1`
- Node.js: `2.1.0` → `2.1.1`
- Python: `0.2.0` → `0.2.1`
- Go: tagged via git after merge

Version bump only, no code changes. Follows #65.

🤖 Generated with [Claude Code](https://claude.com/claude-code)