### PR TITLE
fix(ci): add --allow-dirty to cargo publish

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -54,6 +54,6 @@ jobs:
 
       - name: Publish
         if: inputs.dry_run != 'true'
-        run: cargo publish
+        run: cargo publish --allow-dirty
         env:
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary
- `cargo publish` fails because `Cargo.lock` is regenerated at build time
- `cargo package` and dry-run already use `--allow-dirty`; the actual publish step was missing it

One-line fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)