### PR TITLE
feat(auth): handle need_verifycode in QR login flow

### DIFF
--- a/nodejs/src/auth/authenticator.ts
+++ b/nodejs/src/auth/authenticator.ts
@@ -97,14 +97,18 @@ export class Authenticator {
       let lastStatus: string | undefined
       // Current polling URL; may be updated on IDC redirect
       let currentPollBaseUrl = FIXED_QR_BASE_URL
+      // Verification code pending submission on the next poll (see need_verifycode).
+      let pendingVerifyCode: string | undefined
 
       for (;;) {
-        const status = await this.api.pollQrStatus(currentPollBaseUrl, qr.qrcode)
+        const status = await this.api.pollQrStatus(currentPollBaseUrl, qr.qrcode, pendingVerifyCode)
 
         if (status.status !== lastStatus) {
           lastStatus = status.status
 
           if (status.status === 'scaned') {
+            // Reaching `scaned` after a code submission means it was accepted.
+            pendingVerifyCode = undefined
             this.logger.info('QR scanned — confirm in WeChat')
             callbacks?.onScanned?.()
           } else if (status.status === 'expired') {
@@ -113,6 +117,26 @@ export class Authenticator {
           } else if (status.status === 'confirmed') {
             this.logger.info('Login confirmed')
           }
+        }
+
+        // Server is challenging with a verification code shown in the scanning
+        // user's WeChat app. Ask the caller for it, then re-poll immediately.
+        if (status.status === 'need_verifycode') {
+          if (!callbacks?.onNeedVerifyCode) {
+            throw new AuthError(
+              'Server requires a verification code (need_verifycode) but no onNeedVerifyCode callback was provided',
+            )
+          }
+          pendingVerifyCode = (await callbacks.onNeedVerifyCode()).trim()
+          // Re-poll immediately with the submitted code (skip the poll delay).
+          continue
+        }
+
+        // Too many wrong codes — the server locked further attempts.
+        if (status.status === 'verify_code_blocked') {
+          pendingVerifyCode = undefined
+          callbacks?.onVerifyCodeBlocked?.()
+          throw new AuthError('Verification code rejected too many times (verify_code_blocked)')
         }
 
         if (status.status === 'confirmed') {

--- a/nodejs/src/auth/types.ts
+++ b/nodejs/src/auth/types.ts
@@ -13,4 +13,14 @@ export interface QrLoginCallbacks {
   onScanned?: () => void
   /** Called when the QR code has expired and a new one will be requested. */
   onExpired?: () => void
+  /**
+   * Called when the server requires a verification code (`need_verifycode`):
+   * WeChat shows a short numeric code in the scanning user's app that must be
+   * entered to continue. Return the code the user provided (login re-polls with
+   * it immediately). If this callback is not supplied, login throws on
+   * `need_verifycode`.
+   */
+  onNeedVerifyCode?: () => string | Promise<string>
+  /** Called when the verification code was rejected too many times (`verify_code_blocked`). */
+  onVerifyCodeBlocked?: () => void
 }

--- a/nodejs/src/protocol/api.ts
+++ b/nodejs/src/protocol/api.ts
@@ -39,12 +39,16 @@ export class ILinkApi {
     )
   }
 
-  async pollQrStatus(baseUrl: string, qrcode: string): Promise<QrStatusResponse> {
-    return this.http.apiGet<QrStatusResponse>(
-      baseUrl,
-      `/ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`,
-      buildCommonHeaders(),
-    )
+  async pollQrStatus(
+    baseUrl: string,
+    qrcode: string,
+    verifyCode?: string,
+  ): Promise<QrStatusResponse> {
+    let path = `/ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`
+    if (verifyCode) {
+      path += `&verify_code=${encodeURIComponent(verifyCode)}`
+    }
+    return this.http.apiGet<QrStatusResponse>(baseUrl, path, buildCommonHeaders())
   }
 
   // ── Messages ──────────────────────────────────────────────────────────

--- a/nodejs/src/protocol/types.ts
+++ b/nodejs/src/protocol/types.ts
@@ -190,7 +190,14 @@ export interface QrCodeResponse {
 }
 
 export interface QrStatusResponse {
-  status: 'wait' | 'scaned' | 'confirmed' | 'expired' | 'scaned_but_redirect'
+  status:
+    | 'wait'
+    | 'scaned'
+    | 'confirmed'
+    | 'expired'
+    | 'scaned_but_redirect'
+    | 'need_verifycode'
+    | 'verify_code_blocked'
   bot_token?: string
   ilink_bot_id?: string
   ilink_user_id?: string

--- a/nodejs/tests/auth.test.ts
+++ b/nodejs/tests/auth.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect, vi } from 'vitest'
+import { Authenticator } from '../src/auth/authenticator.js'
+import { MemoryStorage } from '../src/storage/memory.js'
+import { createLogger } from '../src/logger/logger.js'
+import type { ILinkApi } from '../src/protocol/api.js'
+import type { QrCodeResponse, QrStatusResponse } from '../src/protocol/types.js'
+
+const logger = createLogger({ level: 'silent' })
+
+/** Build a fake ILinkApi that replays a scripted sequence of QR statuses. */
+function makeApi(statuses: QrStatusResponse[]) {
+  const verifyCodes: Array<string | undefined> = []
+  let i = 0
+  const api = {
+    getQrCode: vi.fn(
+      async (): Promise<QrCodeResponse> => ({
+        qrcode: 'qr-1',
+        qrcode_img_content: 'https://example.test/qr.png',
+      }),
+    ),
+    pollQrStatus: vi.fn(
+      async (_baseUrl: string, _qrcode: string, verifyCode?: string): Promise<QrStatusResponse> => {
+        verifyCodes.push(verifyCode)
+        return statuses[Math.min(i++, statuses.length - 1)]
+      },
+    ),
+  }
+  return { api: api as unknown as ILinkApi, verifyCodes }
+}
+
+describe('Authenticator need_verifycode flow', () => {
+  it('submits the verification code and completes login', async () => {
+    const { api, verifyCodes } = makeApi([
+      { status: 'need_verifycode' },
+      {
+        status: 'confirmed',
+        bot_token: 'tok',
+        ilink_bot_id: 'bot-1',
+        ilink_user_id: 'user-1',
+        baseurl: 'https://backend.test',
+      },
+    ])
+    const auth = new Authenticator(api, new MemoryStorage(), logger)
+    const onNeedVerifyCode = vi.fn(() => '123456')
+
+    const creds = await auth.login({ force: true, callbacks: { onNeedVerifyCode } })
+
+    expect(onNeedVerifyCode).toHaveBeenCalledTimes(1)
+    expect(creds.token).toBe('tok')
+    expect(creds.accountId).toBe('bot-1')
+    expect(creds.userId).toBe('user-1')
+    // First poll carries no code; the poll after need_verifycode carries it.
+    expect(verifyCodes).toEqual([undefined, '123456'])
+  })
+
+  it('throws when need_verifycode arrives without an onNeedVerifyCode callback', async () => {
+    const { api } = makeApi([{ status: 'need_verifycode' }])
+    const auth = new Authenticator(api, new MemoryStorage(), logger)
+
+    await expect(auth.login({ force: true })).rejects.toThrow(/need_verifycode/)
+  })
+
+  it('throws and notifies on verify_code_blocked', async () => {
+    const { api } = makeApi([{ status: 'verify_code_blocked' }])
+    const auth = new Authenticator(api, new MemoryStorage(), logger)
+    const onVerifyCodeBlocked = vi.fn()
+
+    await expect(
+      auth.login({
+        force: true,
+        callbacks: { onNeedVerifyCode: () => '0', onVerifyCodeBlocked },
+      }),
+    ).rejects.toThrow(/verify_code_blocked/)
+    expect(onVerifyCodeBlocked).toHaveBeenCalledTimes(1)
+  })
+})


### PR DESCRIPTION
## Problem

The Node.js QR login poll loop (`auth/authenticator.ts`) only recognizes `wait | scaned | confirmed | expired | scaned_but_redirect`. But the iLink backend can challenge a scan with a **verification code** — it returns `status: "need_verifycode"` and shows a short numeric code in the *scanning user's* WeChat app that must be entered to continue (this is the same flow Tencent's upstream `@tencent-weixin/openclaw-weixin` handles in `login-qr.ts`).

Today that status falls through the `switch`, the loop just keeps polling, and **login never completes** (`pollQrStatus` is never sent the code, so the server keeps returning `need_verifycode`). For any account that trips WeChat's verify challenge, QR login hangs until timeout.

## Fix

- **`protocol/api.ts`** — `pollQrStatus(baseUrl, qrcode, verifyCode?)` appends `&verify_code=` when a code is pending.
- **`auth/types.ts`** — add `onNeedVerifyCode?: () => string | Promise<string>` and `onVerifyCodeBlocked?: () => void` to `QrLoginCallbacks`.
- **`auth/authenticator.ts`** — on `need_verifycode`, ask the caller for the code via `onNeedVerifyCode` and re-poll immediately with it; clear it once accepted (`scaned`). On `verify_code_blocked`, notify and throw. If `need_verifycode` arrives with no callback configured, throw a clear `AuthError` instead of looping forever.
- **`protocol/types.ts`** — extend `QrStatusResponse.status` with `need_verifycode | verify_code_blocked`.

Behavior is unchanged when the backend never sends `need_verifycode`.

## Tests

Added `tests/auth.test.ts` covering: code submitted → login completes (and the post-challenge poll carries the code), `need_verifycode` with no callback throws, and `verify_code_blocked` throws + notifies.

```
Test Files  9 passed (9)
     Tests  72 passed (72)
```
`tsc --noEmit` (the `lint` script) passes.

## Notes

- Scoped to the **Node.js SDK** (where I hit this). The Python / Go / Rust SDKs share the same gap — happy to follow up if you'd like them in the same PR or separate ones.
- `binded_redirect` (re-scan of an already-bound bot) is another upstream status not handled here; left out to keep this focused on the login-blocking case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)