### PR TITLE
feat: add notifystart/notifystop connection status endpoints to all SDKs

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -62,6 +62,19 @@ POST /ilink/bot/sendtyping
 Body: { ilink_user_id: "<id>", typing_ticket: "<ticket>", status: 1|2, base_info: {...} }
 ```
 
+## Connection Status Notify
+```
+POST /ilink/bot/msg/notifystart
+Body: { base_info: {...} }
+→ { ret: 0 }
+
+POST /ilink/bot/msg/notifystop
+Body: { base_info: {...} }
+→ { ret: 0 }
+```
+Sent when the bot client starts / stops polling so the server can track per-account
+online state. Failures are non-fatal — log and continue.
+
 ## Media Upload
 ```
 POST /ilink/bot/getuploadurl

--- a/golang/bot.go
+++ b/golang/bot.go
@@ -261,6 +261,23 @@ func (b *Bot) Run(ctx context.Context) error {
 	b.cancelPoll = cancel
 	b.mu.Unlock()
 
+	// Tell the server we're coming online (non-fatal)
+	if err := b.client.NotifyStart(pollCtx, creds.BaseURL, creds.Token); err != nil {
+		b.log("warn", "notifystart failed (ignored): %v", err)
+	}
+
+	// Tell the server we're going offline when the loop exits (non-fatal).
+	// Uses a fresh context because pollCtx is already canceled on Stop().
+	defer func() {
+		stopCtx, cancelStop := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancelStop()
+		if c := b.getCreds(); c != nil {
+			if err := b.client.NotifyStop(stopCtx, c.BaseURL, c.Token); err != nil {
+				b.log("warn", "notifystop failed (ignored): %v", err)
+			}
+		}
+	}()
+
 	b.log("info", "Long-poll loop started")
 	retryDelay := time.Second
 

--- a/golang/internal/protocol/api.go
+++ b/golang/internal/protocol/api.go
@@ -250,6 +250,20 @@ func (c *Client) SendTyping(ctx context.Context, baseURL, token, userID, ticket 
 	return err
 }
 
+// NotifyStart notifies the server that this client is starting (coming online).
+func (c *Client) NotifyStart(ctx context.Context, baseURL, token string) error {
+	body := map[string]interface{}{"base_info": baseInfo()}
+	_, err := c.apiPost(ctx, baseURL, "/ilink/bot/msg/notifystart", token, body, 15*time.Second)
+	return err
+}
+
+// NotifyStop notifies the server that this client is stopping (going offline).
+func (c *Client) NotifyStop(ctx context.Context, baseURL, token string) error {
+	body := map[string]interface{}{"base_info": baseInfo()}
+	_, err := c.apiPost(ctx, baseURL, "/ilink/bot/msg/notifystop", token, body, 15*time.Second)
+	return err
+}
+
 // GetUploadURLRequest holds parameters for getuploadurl.
 type GetUploadURLRequest struct {
 	FileKey       string `json:"filekey"`

--- a/nodejs/src/core/client.ts
+++ b/nodejs/src/core/client.ts
@@ -415,6 +415,11 @@ export class WeChatBot extends TypedEmitter<BotEventMap> {
       this.poller.loadCursor(),
     ])
 
+    // Tell the server we're coming online (non-fatal)
+    await this.api.notifyStart(creds.baseUrl, creds.token).catch((error) => {
+      this.logger.warn(`notifyStart failed (ignored): ${error instanceof Error ? error.message : String(error)}`)
+    })
+
     this.emit('poll:start')
     this.runPromise = this.poller.start(creds.baseUrl, creds.token)
 
@@ -422,6 +427,12 @@ export class WeChatBot extends TypedEmitter<BotEventMap> {
       await this.runPromise
     } finally {
       this.runPromise = null
+      // Tell the server we're going offline (non-fatal).
+      // Credentials may have rotated after a mid-poll re-login, so re-read them.
+      const current = this.credentials ?? creds
+      await this.api.notifyStop(current.baseUrl, current.token).catch((error) => {
+        this.logger.warn(`notifyStop failed (ignored): ${error instanceof Error ? error.message : String(error)}`)
+      })
       this.emit('poll:stop')
     }
   }

--- a/nodejs/src/protocol/api.ts
+++ b/nodejs/src/protocol/api.ts
@@ -108,6 +108,26 @@ export class ILinkApi {
     )
   }
 
+  // ── Lifecycle ─────────────────────────────────────────────────────────
+
+  async notifyStart(baseUrl: string, token: string): Promise<Record<string, unknown>> {
+    return this.http.apiPost<Record<string, unknown>>(
+      baseUrl,
+      '/ilink/bot/msg/notifystart',
+      { base_info: baseInfo() },
+      buildAuthHeaders(token),
+    )
+  }
+
+  async notifyStop(baseUrl: string, token: string): Promise<Record<string, unknown>> {
+    return this.http.apiPost<Record<string, unknown>>(
+      baseUrl,
+      '/ilink/bot/msg/notifystop',
+      { base_info: baseInfo() },
+      buildAuthHeaders(token),
+    )
+  }
+
   // ── Media ─────────────────────────────────────────────────────────────
 
   async getUploadUrl(

--- a/python/wechatbot/client.py
+++ b/python/wechatbot/client.py
@@ -252,6 +252,13 @@ class WeChatBot:
         """Start the long-poll loop. Blocks until stop() is called."""
         creds = self._require_creds()
         self._stopped = False
+
+        # Tell the server we're coming online (non-fatal)
+        try:
+            await self._api.notify_start(creds.base_url, creds.token)
+        except Exception as e:
+            self._log(f"notify_start failed (ignored): {e}")
+
         self._log("Long-poll started")
         retry_delay = 1.0
 
@@ -300,6 +307,14 @@ class WeChatBot:
                 self._report_error(e)
                 await asyncio.sleep(retry_delay)
                 retry_delay = min(retry_delay * 2, 10.0)
+
+        # Tell the server we're going offline (non-fatal).
+        # Credentials may have rotated after a mid-poll re-login, so re-read them.
+        try:
+            creds = self._require_creds()
+            await self._api.notify_stop(creds.base_url, creds.token)
+        except Exception as e:
+            self._log(f"notify_stop failed (ignored): {e}")
 
         self._log("Long-poll stopped")
 

--- a/python/wechatbot/protocol.py
+++ b/python/wechatbot/protocol.py
@@ -152,6 +152,16 @@ class ILinkApi:
         }
         return await self._post(base_url, "/ilink/bot/sendtyping", token, body)
 
+    async def notify_start(self, base_url: str, token: str) -> dict[str, Any]:
+        """Notify the server that this client is starting (coming online)."""
+        body = {"base_info": _base_info()}
+        return await self._post(base_url, "/ilink/bot/msg/notifystart", token, body)
+
+    async def notify_stop(self, base_url: str, token: str) -> dict[str, Any]:
+        """Notify the server that this client is stopping (going offline)."""
+        body = {"base_info": _base_info()}
+        return await self._post(base_url, "/ilink/bot/msg/notifystop", token, body)
+
     @staticmethod
     def build_media_message(
         user_id: str,

--- a/rust/src/bot.rs
+++ b/rust/src/bot.rs
@@ -296,6 +296,15 @@ impl WeChatBot {
     /// Start the long-poll loop. Blocks until stopped.
     pub async fn run(&self) -> Result<()> {
         *self.stopped.write().await = false;
+
+        // Tell the server we're coming online (non-fatal)
+        {
+            let (base_url, token) = self.get_auth().await?;
+            if let Err(e) = self.client.notify_start(&base_url, &token).await {
+                warn!("notify_start failed (ignored): {}", e);
+            }
+        }
+
         info!("Long-poll loop started");
         let mut retry_delay = Duration::from_secs(1);
 
@@ -339,6 +348,14 @@ impl WeChatBot {
                     retry_delay = std::cmp::min(retry_delay * 2, Duration::from_secs(10));
                     continue;
                 }
+            }
+        }
+
+        // Tell the server we're going offline (non-fatal).
+        // Credentials may have rotated after a mid-poll re-login, so re-read them.
+        if let Ok((base_url, token)) = self.get_auth().await {
+            if let Err(e) = self.client.notify_stop(&base_url, &token).await {
+                warn!("notify_stop failed (ignored): {}", e);
             }
         }
 

--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -195,6 +195,22 @@ impl ILinkClient {
         Ok(())
     }
 
+    /// Notify the server that this client is starting (coming online).
+    pub async fn notify_start(&self, base_url: &str, token: &str) -> Result<()> {
+        let body = json!({ "base_info": { "channel_version": CHANNEL_VERSION } });
+        self.api_post(base_url, "/ilink/bot/msg/notifystart", token, &body, 15)
+            .await?;
+        Ok(())
+    }
+
+    /// Notify the server that this client is stopping (going offline).
+    pub async fn notify_stop(&self, base_url: &str, token: &str) -> Result<()> {
+        let body = json!({ "base_info": { "channel_version": CHANNEL_VERSION } });
+        self.api_post(base_url, "/ilink/bot/msg/notifystop", token, &body, 15)
+            .await?;
+        Ok(())
+    }
+
     async fn api_post(
         &self,
         base_url: &str,


### PR DESCRIPTION
## Summary

Ports the connection-status notify protocol from upstream [openclaw-weixin](https://github.com/Tencent/openclaw-weixin) v2.1.10/v2.3.1 to all four SDKs:

- **New endpoints**: `POST ilink/bot/msg/notifystart` (sent when the poll loop starts) and `POST ilink/bot/msg/notifystop` (sent when it exits), body `{ base_info }`, response `{ ret, errmsg }`. These let the Weixin server reconcile per-account online state.
- **Non-fatal semantics**: failures are logged as warnings and ignored, matching upstream.
- **notifyStop uses current credentials**: re-read at loop exit since a mid-poll re-login can rotate the token. Go uses a fresh 15s-timeout context since the poll context is already canceled on `Stop()`.
- `docs/protocol.md` documents the two endpoints.

Part 1 of 3 porting upstream v2.1.7 → v2.4.6 protocol changes (next: `bot_agent` + `local_token_list` + `binded_redirect`, then pair-code login).

## Test plan

- [x] Node: `tsc --noEmit` + vitest (69 passed)
- [x] Go: `go build ./... && go vet ./... && go test ./...`
- [x] Rust: `cargo build && cargo test`
- [x] Python: pytest (22 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)