### PR TITLE
feat: add bot_agent, local_token_list, and binded_redirect to all SDKs

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -17,14 +17,19 @@ a duplicate session.
 
 ### Step 2: Poll Status
 ```
-GET /ilink/bot/get_qrcode_status?qrcode=<token>
+GET /ilink/bot/get_qrcode_status?qrcode=<token>[&verify_code=<digits>]
 Headers: { "iLink-App-ClientVersion": "1" }
-→ { status: "wait" | "scaned" | "confirmed" | "expired" | "scaned_but_redirect" | "binded_redirect",
+→ { status: "wait" | "scaned" | "confirmed" | "expired" | "scaned_but_redirect"
+          | "binded_redirect" | "need_verifycode" | "verify_code_blocked",
     bot_token?, ilink_bot_id?, ilink_user_id?, baseurl?, redirect_host? }
 ```
 - `scaned_but_redirect`: switch polling to `https://<redirect_host>` (IDC redirect)
 - `binded_redirect`: the scanned bot is already bound to this client (matched via
   `local_token_list`) — treat as success and reuse existing local credentials
+- `need_verifycode`: pair-code challenge — prompt the user for the digits shown in
+  WeChat on their phone and re-poll with `&verify_code=`. Getting `need_verifycode`
+  again means the code was wrong (re-prompt); getting `scaned` means it was accepted.
+- `verify_code_blocked`: too many wrong codes — this QR is dead, request a new one
 
 ## Common Headers (all POST requests)
 ```

--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -7,16 +7,24 @@ CDN URL: `https://novac2c.cdn.weixin.qq.com/c2c`
 
 ### Step 1: Get QR Code
 ```
-GET /ilink/bot/get_bot_qrcode?bot_type=3
+POST /ilink/bot/get_bot_qrcode?bot_type=3
+Body: { local_token_list: ["<bot_token>", ...] }
 → { qrcode: "<token>", qrcode_img_content: "<url>" }
 ```
+`local_token_list` carries up to 10 known local bot tokens (newest first) so the
+server can answer `binded_redirect` for an already-bound bot instead of issuing
+a duplicate session.
 
 ### Step 2: Poll Status
 ```
 GET /ilink/bot/get_qrcode_status?qrcode=<token>
 Headers: { "iLink-App-ClientVersion": "1" }
-→ { status: "wait" | "scaned" | "confirmed" | "expired", bot_token?, ilink_bot_id?, ilink_user_id?, baseurl? }
+→ { status: "wait" | "scaned" | "confirmed" | "expired" | "scaned_but_redirect" | "binded_redirect",
+    bot_token?, ilink_bot_id?, ilink_user_id?, baseurl?, redirect_host? }
 ```
+- `scaned_but_redirect`: switch polling to `https://<redirect_host>` (IDC redirect)
+- `binded_redirect`: the scanned bot is already bound to this client (matched via
+  `local_token_list`) — treat as success and reuse existing local credentials
 
 ## Common Headers (all POST requests)
 ```
@@ -25,7 +33,12 @@ AuthorizationType: ilink_bot_token
 Authorization: Bearer <bot_token>
 X-WECHAT-UIN: <base64(String(randomUint32))>
 ```
-All POST bodies include: `base_info: { channel_version: "<version>" }`
+All authorized POST bodies include:
+`base_info: { channel_version: "<version>", bot_agent: "<name>/<version> [(comment)]" }`
+
+`bot_agent` identifies the app driving the bot, UA-style grammar
+(`product *( SP product )`, product = `name "/" version [ SP "(" comment ")" ]`,
+max 256 bytes). Defaults to `WeChatBot/<version>` when unset or invalid.
 
 ## Get Updates (Long Poll)
 ```

--- a/golang/bot.go
+++ b/golang/bot.go
@@ -35,6 +35,10 @@ type Options struct {
 	OnScanned    func()
 	OnExpired    func()
 	OnError      func(err error)
+	// BotAgent identifies the app driving this bot, sent as base_info.bot_agent
+	// on every API request (e.g. "MyApp/1.2 (prod)"). Invalid values fall back
+	// to protocol.DefaultBotAgent.
+	BotAgent     string
 }
 
 // Bot is the main WeChat bot client.
@@ -59,9 +63,11 @@ func New(opts ...Options) *Bot {
 	if o.BaseURL == "" {
 		o.BaseURL = protocol.DefaultBaseURL
 	}
+	client := protocol.NewClient()
+	client.BotAgent = protocol.SanitizeBotAgent(o.BotAgent)
 	return &Bot{
 		opts:   o,
-		client: protocol.NewClient(),
+		client: client,
 	}
 }
 

--- a/golang/bot.go
+++ b/golang/bot.go
@@ -35,6 +35,10 @@ type Options struct {
 	OnScanned    func()
 	OnExpired    func()
 	OnError      func(err error)
+	// OnVerifyCode is called when the server requires a pairing code (the
+	// digits shown in WeChat on the user's phone). isRetry is true when a
+	// previously submitted code was rejected. Defaults to a stdin prompt.
+	OnVerifyCode func(isRetry bool) (string, error)
 	// BotAgent identifies the app driving this bot, sent as base_info.bot_agent
 	// on every API request (e.g. "MyApp/1.2 (prod)"). Invalid values fall back
 	// to protocol.DefaultBotAgent.
@@ -77,9 +81,10 @@ func (b *Bot) Login(ctx context.Context, force bool) (*Credentials, error) {
 		BaseURL:   b.opts.BaseURL,
 		CredPath:  b.opts.CredPath,
 		Force:     force,
-		OnQRURL:   b.opts.OnQRURL,
-		OnScanned: b.opts.OnScanned,
-		OnExpired: b.opts.OnExpired,
+		OnQRURL:      b.opts.OnQRURL,
+		OnScanned:    b.opts.OnScanned,
+		OnExpired:    b.opts.OnExpired,
+		OnVerifyCode: b.opts.OnVerifyCode,
 	})
 	if err != nil {
 		return nil, err

--- a/golang/internal/auth/login.go
+++ b/golang/internal/auth/login.go
@@ -91,11 +91,16 @@ func Login(ctx context.Context, client *protocol.Client, opts LoginOptions) (*Cr
 		baseURL = protocol.DefaultBaseURL
 	}
 
-	if !opts.Force {
-		creds, err := LoadCredentials(opts.CredPath)
-		if err == nil && creds != nil {
-			return creds, nil
-		}
+	stored, _ := LoadCredentials(opts.CredPath)
+	if !opts.Force && stored != nil {
+		return stored, nil
+	}
+
+	// Send known local tokens so the server can answer binded_redirect
+	// instead of issuing a duplicate session for an already-bound bot.
+	var localTokenList []string
+	if stored != nil && stored.Token != "" {
+		localTokenList = []string{stored.Token}
 	}
 
 	qrRefreshCount := 0
@@ -105,7 +110,7 @@ func Login(ctx context.Context, client *protocol.Client, opts LoginOptions) (*Cr
 			return nil, fmt.Errorf("QR code expired %d times — login aborted", maxQRRefreshCount)
 		}
 
-		qr, err := client.GetQRCode(ctx, fixedQRBaseURL)
+		qr, err := client.GetQRCode(ctx, fixedQRBaseURL, localTokenList)
 		if err != nil {
 			return nil, fmt.Errorf("get QR code: %w", err)
 		}
@@ -163,6 +168,15 @@ func Login(ctx context.Context, client *protocol.Client, opts LoginOptions) (*Cr
 					fmt.Fprintf(os.Stderr, "[wechatbot] Warning: could not save credentials: %v\n", err)
 				}
 				return creds, nil
+			}
+
+			// Already bound to this client: reuse existing local credentials
+			if status.Status == "binded_redirect" {
+				if stored != nil {
+					fmt.Fprintln(os.Stderr, "[wechatbot] Bot already bound — reusing stored credentials")
+					return stored, nil
+				}
+				return nil, fmt.Errorf("server reports this bot is already bound to this client (binded_redirect), but no local credentials were found")
 			}
 
 			// Handle IDC redirect

--- a/golang/internal/auth/login.go
+++ b/golang/internal/auth/login.go
@@ -2,11 +2,13 @@
 package auth
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/corespeed-io/wechatbot/golang/internal/protocol"
@@ -75,6 +77,25 @@ type LoginOptions struct {
 	OnQRURL   func(url string)
 	OnScanned func()
 	OnExpired func()
+	// OnVerifyCode is called when the server requires a pairing code (the
+	// digits shown in WeChat on the user's phone). isRetry is true when a
+	// previously submitted code was rejected. Defaults to a stdin prompt.
+	OnVerifyCode func(isRetry bool) (string, error)
+}
+
+// readVerifyCode is the default pairing-code prompt: read a line from stdin.
+func readVerifyCode(isRetry bool) (string, error) {
+	prompt := "Enter the pairing code shown in WeChat on your phone: "
+	if isRetry {
+		prompt = "Code mismatch — enter the pairing code shown in WeChat again: "
+	}
+	fmt.Fprint(os.Stderr, prompt)
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(line), nil
 }
 
 const (
@@ -123,8 +144,10 @@ func Login(ctx context.Context, client *protocol.Client, opts LoginOptions) (*Cr
 
 		lastStatus := ""
 		currentPollBaseURL := fixedQRBaseURL
+		// Pairing code awaiting server verification (pair-code login flow)
+		pendingVerifyCode := ""
 		for {
-			status, err := client.PollQRStatus(ctx, currentPollBaseURL, qr.QRCode)
+			status, err := client.PollQRStatus(ctx, currentPollBaseURL, qr.QRCode, pendingVerifyCode)
 			if err != nil {
 				return nil, fmt.Errorf("poll QR status: %w", err)
 			}
@@ -133,6 +156,8 @@ func Login(ctx context.Context, client *protocol.Client, opts LoginOptions) (*Cr
 				lastStatus = status.Status
 				switch status.Status {
 				case "scaned":
+					// A pending pairing code that leads back to scaned was accepted
+					pendingVerifyCode = ""
 					if opts.OnScanned != nil {
 						opts.OnScanned()
 					} else {
@@ -168,6 +193,28 @@ func Login(ctx context.Context, client *protocol.Client, opts LoginOptions) (*Cr
 					fmt.Fprintf(os.Stderr, "[wechatbot] Warning: could not save credentials: %v\n", err)
 				}
 				return creds, nil
+			}
+
+			// Pair-code challenge: ask the user for the digits shown in WeChat
+			if status.Status == "need_verifycode" {
+				isRetry := pendingVerifyCode != ""
+				prompt := opts.OnVerifyCode
+				if prompt == nil {
+					prompt = readVerifyCode
+				}
+				code, err := prompt(isRetry)
+				if err != nil {
+					return nil, fmt.Errorf("read pairing code: %w", err)
+				}
+				pendingVerifyCode = code
+				continue // Re-poll immediately with the code attached
+			}
+
+			// Too many wrong pairing codes: server blocked this QR — get a new one
+			if status.Status == "verify_code_blocked" {
+				fmt.Fprintln(os.Stderr, "[wechatbot] Pairing code blocked after repeated mismatches — requesting new QR")
+				pendingVerifyCode = ""
+				break // Outer loop requests a new QR (counts toward refresh limit)
 			}
 
 			// Already bound to this client: reuse existing local credentials

--- a/golang/internal/protocol/api.go
+++ b/golang/internal/protocol/api.go
@@ -130,7 +130,7 @@ type QRCodeResponse struct {
 
 // QRStatusResponse from get_qrcode_status.
 type QRStatusResponse struct {
-	Status       string `json:"status"` // wait, scaned, confirmed, expired, scaned_but_redirect, binded_redirect
+	Status       string `json:"status"` // wait, scaned, confirmed, expired, scaned_but_redirect, binded_redirect, need_verifycode, verify_code_blocked
 	BotToken     string `json:"bot_token,omitempty"`
 	BotID        string `json:"ilink_bot_id,omitempty"`
 	UserID       string `json:"ilink_user_id,omitempty"`
@@ -182,8 +182,14 @@ func (c *Client) GetQRCode(ctx context.Context, baseURL string, localTokenList [
 }
 
 // PollQRStatus polls the QR code scan status.
-func (c *Client) PollQRStatus(ctx context.Context, baseURL, qrcode string) (*QRStatusResponse, error) {
+//
+// verifyCode submits a pairing code after the server answered need_verifycode
+// (the digits shown in WeChat on the user's phone). Pass "" when none.
+func (c *Client) PollQRStatus(ctx context.Context, baseURL, qrcode, verifyCode string) (*QRStatusResponse, error) {
 	u := baseURL + "/ilink/bot/get_qrcode_status?qrcode=" + url.QueryEscape(qrcode)
+	if verifyCode != "" {
+		u += "&verify_code=" + url.QueryEscape(verifyCode)
+	}
 	req, _ := http.NewRequestWithContext(ctx, "GET", u, nil)
 	for k, v := range CommonHeaders() {
 		req.Header[k] = v

--- a/golang/internal/protocol/api.go
+++ b/golang/internal/protocol/api.go
@@ -304,14 +304,14 @@ func (c *Client) SendTyping(ctx context.Context, baseURL, token, userID, ticket 
 
 // NotifyStart notifies the server that this client is starting (coming online).
 func (c *Client) NotifyStart(ctx context.Context, baseURL, token string) error {
-	body := map[string]interface{}{"base_info": baseInfo()}
+	body := map[string]interface{}{"base_info": c.baseInfo()}
 	_, err := c.apiPost(ctx, baseURL, "/ilink/bot/msg/notifystart", token, body, 15*time.Second)
 	return err
 }
 
 // NotifyStop notifies the server that this client is stopping (going offline).
 func (c *Client) NotifyStop(ctx context.Context, baseURL, token string) error {
-	body := map[string]interface{}{"base_info": baseInfo()}
+	body := map[string]interface{}{"base_info": c.baseInfo()}
 	_, err := c.apiPost(ctx, baseURL, "/ilink/bot/msg/notifystop", token, body, 15*time.Second)
 	return err
 }

--- a/golang/internal/protocol/api.go
+++ b/golang/internal/protocol/api.go
@@ -12,9 +12,10 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
+	"strings"
 	"time"
-
 )
 
 const (
@@ -69,13 +70,41 @@ func AuthHeaders(token string) http.Header {
 	return h
 }
 
-func baseInfo() map[string]string {
-	return map[string]string{"channel_version": ChannelVersion}
+// DefaultBotAgent is used when no bot_agent is configured or the configured
+// value is invalid.
+const DefaultBotAgent = "WeChatBot/" + ChannelVersion
+
+// Maximum length (bytes) of the sanitized bot_agent string.
+const botAgentMaxLen = 256
+
+// UA-style grammar (matches openclaw-weixin):
+//
+//	bot_agent = product *( SP product )
+//	product   = name "/" version [ SP "(" comment ")" ]
+var botAgentRe = regexp.MustCompile(
+	`^[A-Za-z0-9_.\-]{1,32}/[A-Za-z0-9_.+\-]{1,32}( \([\x20-\x27\x2A-\x7E]{1,64}\))?` +
+		`( [A-Za-z0-9_.\-]{1,32}/[A-Za-z0-9_.+\-]{1,32}( \([\x20-\x27\x2A-\x7E]{1,64}\))?)*$`,
+)
+
+// SanitizeBotAgent validates a user-supplied bot_agent into a wire-safe string.
+//
+// Unlike upstream openclaw-weixin (which salvages the valid tokens out of a
+// partially invalid string), any invalid input falls back to DefaultBotAgent
+// wholesale — simpler and just as safe on the wire.
+func SanitizeBotAgent(raw string) string {
+	normalized := strings.Join(strings.Fields(raw), " ")
+	if normalized == "" || len(normalized) > botAgentMaxLen || !botAgentRe.MatchString(normalized) {
+		return DefaultBotAgent
+	}
+	return normalized
 }
 
 // Client wraps HTTP calls to the iLink API.
 type Client struct {
 	HTTP *http.Client
+	// BotAgent identifies the app driving this bot; sent as base_info.bot_agent.
+	// Empty means DefaultBotAgent.
+	BotAgent string
 }
 
 // NewClient creates a protocol client with sensible defaults.
@@ -83,6 +112,14 @@ func NewClient() *Client {
 	return &Client{
 		HTTP: &http.Client{Timeout: 45 * time.Second},
 	}
+}
+
+func (c *Client) baseInfo() map[string]string {
+	agent := c.BotAgent
+	if agent == "" {
+		agent = DefaultBotAgent
+	}
+	return map[string]string{"channel_version": ChannelVersion, "bot_agent": agent}
 }
 
 // QRCodeResponse from get_bot_qrcode.
@@ -93,7 +130,7 @@ type QRCodeResponse struct {
 
 // QRStatusResponse from get_qrcode_status.
 type QRStatusResponse struct {
-	Status       string `json:"status"` // wait, scaned, confirmed, expired, scaned_but_redirect
+	Status       string `json:"status"` // wait, scaned, confirmed, expired, scaned_but_redirect, binded_redirect
 	BotToken     string `json:"bot_token,omitempty"`
 	BotID        string `json:"ilink_bot_id,omitempty"`
 	UserID       string `json:"ilink_user_id,omitempty"`
@@ -117,12 +154,21 @@ type GetConfigResponse struct {
 }
 
 // GetQRCode requests a new QR code for login.
-func (c *Client) GetQRCode(ctx context.Context, baseURL string) (*QRCodeResponse, error) {
+//
+// localTokenList carries up to 10 known local bot tokens (newest first) so
+// the server can answer binded_redirect for an already-bound bot instead of
+// issuing a duplicate session.
+func (c *Client) GetQRCode(ctx context.Context, baseURL string, localTokenList []string) (*QRCodeResponse, error) {
+	if localTokenList == nil {
+		localTokenList = []string{}
+	}
+	body, _ := json.Marshal(map[string]interface{}{"local_token_list": localTokenList})
 	u := baseURL + "/ilink/bot/get_bot_qrcode?bot_type=3"
-	req, _ := http.NewRequestWithContext(ctx, "GET", u, nil)
+	req, _ := http.NewRequestWithContext(ctx, "POST", u, bytes.NewReader(body))
 	for k, v := range CommonHeaders() {
 		req.Header[k] = v
 	}
+	req.Header.Set("Content-Type", "application/json")
 	resp, err := c.HTTP.Do(req)
 	if err != nil {
 		return nil, fmt.Errorf("get_bot_qrcode: %w", err)
@@ -201,7 +247,7 @@ func (c *Client) apiPost(ctx context.Context, baseURL, endpoint, token string, b
 func (c *Client) GetUpdates(ctx context.Context, baseURL, token, cursor string) (*GetUpdatesResponse, error) {
 	body := map[string]interface{}{
 		"get_updates_buf": cursor,
-		"base_info":       baseInfo(),
+		"base_info":       c.baseInfo(),
 	}
 	raw, err := c.apiPost(ctx, baseURL, "/ilink/bot/getupdates", token, body, 45*time.Second)
 	if err != nil {
@@ -216,7 +262,7 @@ func (c *Client) GetUpdates(ctx context.Context, baseURL, token, cursor string) 
 func (c *Client) SendMessage(ctx context.Context, baseURL, token string, msg interface{}) error {
 	body := map[string]interface{}{
 		"msg":       msg,
-		"base_info": baseInfo(),
+		"base_info": c.baseInfo(),
 	}
 	_, err := c.apiPost(ctx, baseURL, "/ilink/bot/sendmessage", token, body, 15*time.Second)
 	return err
@@ -227,7 +273,7 @@ func (c *Client) GetConfig(ctx context.Context, baseURL, token, userID, contextT
 	body := map[string]interface{}{
 		"ilink_user_id": userID,
 		"context_token": contextToken,
-		"base_info":     baseInfo(),
+		"base_info":     c.baseInfo(),
 	}
 	raw, err := c.apiPost(ctx, baseURL, "/ilink/bot/getconfig", token, body, 15*time.Second)
 	if err != nil {
@@ -244,7 +290,7 @@ func (c *Client) SendTyping(ctx context.Context, baseURL, token, userID, ticket 
 		"ilink_user_id":  userID,
 		"typing_ticket":  ticket,
 		"status":         status,
-		"base_info":      baseInfo(),
+		"base_info":      c.baseInfo(),
 	}
 	_, err := c.apiPost(ctx, baseURL, "/ilink/bot/sendtyping", token, body, 15*time.Second)
 	return err
@@ -284,7 +330,7 @@ func (c *Client) GetUploadURL(ctx context.Context, baseURL, token string, req Ge
 		"filesize":       req.FileSize,
 		"no_need_thumb":  req.NoNeedThumb,
 		"aeskey":         req.AESKey,
-		"base_info":      baseInfo(),
+		"base_info":      c.baseInfo(),
 	}
 	raw, err := c.apiPost(ctx, baseURL, "/ilink/bot/getuploadurl", token, body, 15*time.Second)
 	if err != nil {

--- a/golang/internal/protocol/bot_agent_test.go
+++ b/golang/internal/protocol/bot_agent_test.go
@@ -1,0 +1,36 @@
+package protocol
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestSanitizeBotAgent(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", DefaultBotAgent},
+		{"whitespace only", "   ", DefaultBotAgent},
+		{"single product", "MyApp/1.2", "MyApp/1.2"},
+		{"product with comment", "MyApp/1.2 (prod build)", "MyApp/1.2 (prod build)"},
+		{"multiple products", "MyApp/1.2 (prod) Lib/0.3", "MyApp/1.2 (prod) Lib/0.3"},
+		{"normalizes whitespace", "  MyApp/1.2   Lib/0.3 ", "MyApp/1.2 Lib/0.3"},
+		{"no slash", "no-slash", DefaultBotAgent},
+		{"invalid token", "bad name/1.0 !!!", DefaultBotAgent},
+		{"orphan comment", "(orphan comment)", DefaultBotAgent},
+		{"unclosed comment", "App/1.0 (unclosed", DefaultBotAgent},
+		{"nested comment", "App/1.0 (nested (comment))", DefaultBotAgent},
+		{"name too long", strings.Repeat("a", 33) + "/1.0", DefaultBotAgent},
+		{"version too long", "App/" + strings.Repeat("1", 33), DefaultBotAgent},
+		{"over byte cap", strings.TrimSpace(strings.Repeat("App/1.0 ", 40)), DefaultBotAgent},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := SanitizeBotAgent(tc.in); got != tc.want {
+				t.Errorf("SanitizeBotAgent(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/nodejs/src/auth/authenticator.ts
+++ b/nodejs/src/auth/authenticator.ts
@@ -78,6 +78,11 @@ export class Authenticator {
   private async qrLogin(baseUrl: string, callbacks?: QrLoginCallbacks): Promise<Credentials> {
     let qrRefreshCount = 0
 
+    // Send known local tokens so the server can answer `binded_redirect`
+    // instead of issuing a duplicate session for an already-bound bot.
+    const stored = await this.loadCredentials()
+    const localTokenList = stored?.token ? [stored.token] : []
+
     for (;;) {
       qrRefreshCount++
       if (qrRefreshCount > MAX_QR_REFRESH_COUNT) {
@@ -85,7 +90,7 @@ export class Authenticator {
       }
 
       this.logger.info(`Requesting QR code... (${qrRefreshCount}/${MAX_QR_REFRESH_COUNT})`)
-      const qr = await this.api.getQrCode(FIXED_QR_BASE_URL)
+      const qr = await this.api.getQrCode(FIXED_QR_BASE_URL, localTokenList)
 
       // Pass QR URL to developer's callback — display is their responsibility
       if (callbacks?.onQrUrl) {
@@ -135,6 +140,18 @@ export class Authenticator {
           })
 
           return credentials
+        }
+
+        // Already bound to this client: reuse existing local credentials
+        if (status.status === 'binded_redirect') {
+          if (stored) {
+            this.logger.info('Bot already bound to this client — reusing stored credentials')
+            return stored
+          }
+          throw new AuthError(
+            'Server reports this bot is already bound to this client (binded_redirect), ' +
+              'but no local credentials were found',
+          )
         }
 
         // IDC redirect: switch polling host

--- a/nodejs/src/auth/authenticator.ts
+++ b/nodejs/src/auth/authenticator.ts
@@ -1,3 +1,4 @@
+import { createInterface } from 'node:readline/promises'
 import { setTimeout as delay } from 'node:timers/promises'
 import { AuthError } from '../core/errors.js'
 import type { Logger } from '../logger/types.js'
@@ -102,14 +103,21 @@ export class Authenticator {
       let lastStatus: string | undefined
       // Current polling URL; may be updated on IDC redirect
       let currentPollBaseUrl = FIXED_QR_BASE_URL
+      // Pairing code awaiting server verification (pair-code login flow)
+      let pendingVerifyCode: string | undefined
 
       for (;;) {
-        const status = await this.api.pollQrStatus(currentPollBaseUrl, qr.qrcode)
+        const status = await this.api.pollQrStatus(currentPollBaseUrl, qr.qrcode, pendingVerifyCode)
 
         if (status.status !== lastStatus) {
           lastStatus = status.status
 
           if (status.status === 'scaned') {
+            // A pending pairing code that leads back to `scaned` was accepted
+            if (pendingVerifyCode) {
+              this.logger.info('Pairing code accepted')
+              pendingVerifyCode = undefined
+            }
             this.logger.info('QR scanned — confirm in WeChat')
             callbacks?.onScanned?.()
           } else if (status.status === 'expired') {
@@ -142,6 +150,20 @@ export class Authenticator {
           return credentials
         }
 
+        // Pair-code challenge: ask the user for the digits shown in WeChat
+        if (status.status === 'need_verifycode') {
+          const isRetry = pendingVerifyCode !== undefined
+          pendingVerifyCode = await this.promptVerifyCode(isRetry, callbacks)
+          continue // Re-poll immediately with the code attached
+        }
+
+        // Too many wrong pairing codes: server blocked this QR — request a new one
+        if (status.status === 'verify_code_blocked') {
+          this.logger.warn('Pairing code blocked after repeated mismatches — requesting new QR')
+          pendingVerifyCode = undefined
+          break // Outer loop will request a new QR (counts toward the refresh limit)
+        }
+
         // Already bound to this client: reuse existing local credentials
         if (status.status === 'binded_redirect') {
           if (stored) {
@@ -172,6 +194,29 @@ export class Authenticator {
 
         await delay(QR_POLL_INTERVAL_MS)
       }
+    }
+  }
+
+  /**
+   * Obtain a pairing code from the developer callback, or fall back to a
+   * stdin prompt.
+   */
+  private async promptVerifyCode(
+    isRetry: boolean,
+    callbacks?: QrLoginCallbacks,
+  ): Promise<string> {
+    if (callbacks?.onVerifyCode) {
+      return callbacks.onVerifyCode(isRetry)
+    }
+
+    const prompt = isRetry
+      ? 'Code mismatch — enter the pairing code shown in WeChat again: '
+      : 'Enter the pairing code shown in WeChat on your phone: '
+    const rl = createInterface({ input: process.stdin, output: process.stdout })
+    try {
+      return (await rl.question(prompt)).trim()
+    } finally {
+      rl.close()
     }
   }
 }

--- a/nodejs/src/auth/types.ts
+++ b/nodejs/src/auth/types.ts
@@ -13,4 +13,10 @@ export interface QrLoginCallbacks {
   onScanned?: () => void
   /** Called when the QR code has expired and a new one will be requested. */
   onExpired?: () => void
+  /**
+   * Called when the server requires a pairing code (the digits shown in
+   * WeChat on the user's phone). `isRetry` is true when a previously
+   * submitted code was rejected. Defaults to a stdin prompt.
+   */
+  onVerifyCode?: (isRetry: boolean) => string | Promise<string>
 }

--- a/nodejs/src/core/client.ts
+++ b/nodejs/src/core/client.ts
@@ -38,6 +38,12 @@ export interface WeChatBotOptions {
   logger?: Logger
   /** QR login callbacks (for rendering QR codes, etc.) */
   loginCallbacks?: QrLoginCallbacks
+  /**
+   * UA-style identifier of the app driving this bot, sent as `base_info.bot_agent`
+   * on every API request (e.g. "MyApp/1.2 (prod)"). Invalid values fall back to
+   * "WeChatBot/<version>".
+   */
+  botAgent?: string
 }
 
 // ═══════════════════════════════════════════════════════════════════════
@@ -154,7 +160,7 @@ export class WeChatBot extends TypedEmitter<BotEventMap> {
 
     // Build the layered architecture
     this.http = new HttpClient({ logger: this.logger })
-    this.api = new ILinkApi(this.http)
+    this.api = new ILinkApi(this.http, options.botAgent)
     this.auth = new Authenticator(this.api, this.storage, this.logger)
     this.parser = new MessageParser()
     this.middleware = new MiddlewareEngine()

--- a/nodejs/src/protocol/api.ts
+++ b/nodejs/src/protocol/api.ts
@@ -54,12 +54,21 @@ export class ILinkApi {
     )
   }
 
-  async pollQrStatus(baseUrl: string, qrcode: string): Promise<QrStatusResponse> {
-    return this.http.apiGet<QrStatusResponse>(
-      baseUrl,
-      `/ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`,
-      buildCommonHeaders(),
-    )
+  /**
+   * Poll the QR scan status.
+   * `verifyCode` submits a pairing code after the server answered
+   * `need_verifycode` (the digits shown in WeChat on the user's phone).
+   */
+  async pollQrStatus(
+    baseUrl: string,
+    qrcode: string,
+    verifyCode?: string,
+  ): Promise<QrStatusResponse> {
+    let path = `/ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`
+    if (verifyCode) {
+      path += `&verify_code=${encodeURIComponent(verifyCode)}`
+    }
+    return this.http.apiGet<QrStatusResponse>(baseUrl, path, buildCommonHeaders())
   }
 
   // ── Messages ──────────────────────────────────────────────────────────

--- a/nodejs/src/protocol/api.ts
+++ b/nodejs/src/protocol/api.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import type { HttpClient } from '../transport/http.js'
+import { sanitizeBotAgent } from './bot-agent.js'
 import { buildAuthHeaders, buildCommonHeaders } from './headers.js'
 import {
   CHANNEL_VERSION,
@@ -17,24 +18,38 @@ import {
   type WireMessageItem,
 } from './types.js'
 
-function baseInfo(): BaseInfo {
-  return { channel_version: CHANNEL_VERSION }
-}
-
 /**
  * Low-level iLink API calls.
  * Each method maps 1:1 to an API endpoint.
  * No business logic — just wire protocol.
  */
 export class ILinkApi {
-  constructor(private readonly http: HttpClient) {}
+  private readonly botAgent: string
+
+  constructor(
+    private readonly http: HttpClient,
+    botAgent?: string,
+  ) {
+    this.botAgent = sanitizeBotAgent(botAgent)
+  }
+
+  private baseInfo(): BaseInfo {
+    return { channel_version: CHANNEL_VERSION, bot_agent: this.botAgent }
+  }
 
   // ── Auth ──────────────────────────────────────────────────────────────
 
-  async getQrCode(baseUrl: string): Promise<QrCodeResponse> {
-    return this.http.apiGet<QrCodeResponse>(
+  /**
+   * Request a login QR code.
+   * `localTokenList` carries up to 10 known local bot tokens (newest first) so
+   * the server can answer `binded_redirect` for an already-bound bot instead
+   * of issuing a duplicate session.
+   */
+  async getQrCode(baseUrl: string, localTokenList: string[] = []): Promise<QrCodeResponse> {
+    return this.http.apiPost<QrCodeResponse>(
       baseUrl,
       '/ilink/bot/get_bot_qrcode?bot_type=3',
+      { local_token_list: localTokenList },
       buildCommonHeaders(),
     )
   }
@@ -58,7 +73,7 @@ export class ILinkApi {
     return this.http.apiPost<GetUpdatesResponse>(
       baseUrl,
       '/ilink/bot/getupdates',
-      { get_updates_buf: cursor, base_info: baseInfo() },
+      { get_updates_buf: cursor, base_info: this.baseInfo() },
       buildAuthHeaders(token),
       { timeoutMs: 40_000, signal },
     )
@@ -72,7 +87,7 @@ export class ILinkApi {
     return this.http.apiPost<Record<string, unknown>>(
       baseUrl,
       '/ilink/bot/sendmessage',
-      { msg, base_info: baseInfo() },
+      { msg, base_info: this.baseInfo() },
       buildAuthHeaders(token),
     )
   }
@@ -88,7 +103,7 @@ export class ILinkApi {
     return this.http.apiPost<GetConfigResponse>(
       baseUrl,
       '/ilink/bot/getconfig',
-      { ilink_user_id: userId, context_token: contextToken, base_info: baseInfo() },
+      { ilink_user_id: userId, context_token: contextToken, base_info: this.baseInfo() },
       buildAuthHeaders(token),
     )
   }
@@ -103,7 +118,7 @@ export class ILinkApi {
     return this.http.apiPost<Record<string, unknown>>(
       baseUrl,
       '/ilink/bot/sendtyping',
-      { ilink_user_id: userId, typing_ticket: ticket, status, base_info: baseInfo() },
+      { ilink_user_id: userId, typing_ticket: ticket, status, base_info: this.baseInfo() },
       buildAuthHeaders(token),
     )
   }
@@ -118,7 +133,7 @@ export class ILinkApi {
     return this.http.apiPost<GetUploadUrlResponse>(
       baseUrl,
       '/ilink/bot/getuploadurl',
-      { ...params, base_info: baseInfo() },
+      { ...params, base_info: this.baseInfo() },
       buildAuthHeaders(token),
     )
   }

--- a/nodejs/src/protocol/api.ts
+++ b/nodejs/src/protocol/api.ts
@@ -138,7 +138,7 @@ export class ILinkApi {
     return this.http.apiPost<Record<string, unknown>>(
       baseUrl,
       '/ilink/bot/msg/notifystart',
-      { base_info: baseInfo() },
+      { base_info: this.baseInfo() },
       buildAuthHeaders(token),
     )
   }
@@ -147,7 +147,7 @@ export class ILinkApi {
     return this.http.apiPost<Record<string, unknown>>(
       baseUrl,
       '/ilink/bot/msg/notifystop',
-      { base_info: baseInfo() },
+      { base_info: this.baseInfo() },
       buildAuthHeaders(token),
     )
   }

--- a/nodejs/src/protocol/bot-agent.ts
+++ b/nodejs/src/protocol/bot-agent.ts
@@ -1,0 +1,33 @@
+import { CHANNEL_VERSION } from './types.js'
+
+/** Default `bot_agent` when none is configured or the configured value is invalid. */
+export const DEFAULT_BOT_AGENT = `WeChatBot/${CHANNEL_VERSION}`
+
+/** Maximum length (bytes) of the sanitized `bot_agent` string. */
+const BOT_AGENT_MAX_LEN = 256
+
+/**
+ * UA-style grammar (matches openclaw-weixin):
+ *   bot_agent = product *( SP product )
+ *   product   = name "/" version [ SP "(" comment ")" ]
+ *   name      = 1*32( ALPHA / DIGIT / "_" / "." / "-" )
+ *   version   = 1*32( ALPHA / DIGIT / "_" / "." / "+" / "-" )
+ *   comment   = 1*64( printable ASCII minus "(" ")" )
+ */
+const PRODUCT = String.raw`[A-Za-z0-9_.\-]{1,32}\/[A-Za-z0-9_.+\-]{1,32}(?: \([\x20-\x27\x2A-\x7E]{1,64}\))?`
+const BOT_AGENT_RE = new RegExp(`^${PRODUCT}(?: ${PRODUCT})*$`)
+
+/**
+ * Validate a user-supplied `botAgent` config value into a wire-safe string.
+ *
+ * Unlike upstream openclaw-weixin (which salvages the valid tokens out of a
+ * partially invalid string), any invalid input falls back to
+ * `DEFAULT_BOT_AGENT` wholesale — simpler and just as safe on the wire.
+ */
+export function sanitizeBotAgent(raw?: string): string {
+  const trimmed = raw?.trim()
+  if (!trimmed) return DEFAULT_BOT_AGENT
+  const normalized = trimmed.replace(/\s+/g, ' ')
+  if (Buffer.byteLength(normalized, 'utf-8') > BOT_AGENT_MAX_LEN) return DEFAULT_BOT_AGENT
+  return BOT_AGENT_RE.test(normalized) ? normalized : DEFAULT_BOT_AGENT
+}

--- a/nodejs/src/protocol/index.ts
+++ b/nodejs/src/protocol/index.ts
@@ -1,3 +1,4 @@
 export { ILinkApi } from './api.js'
+export { DEFAULT_BOT_AGENT, sanitizeBotAgent } from './bot-agent.js'
 export { buildAuthHeaders, randomWechatUin } from './headers.js'
 export * from './types.js'

--- a/nodejs/src/protocol/types.ts
+++ b/nodejs/src/protocol/types.ts
@@ -56,6 +56,8 @@ export enum MediaType {
 
 export interface BaseInfo {
   channel_version: string
+  /** UA-style identifier of the app driving this bot (e.g. "MyApp/1.2 (prod)"). */
+  bot_agent?: string
 }
 
 export interface CDNMedia {
@@ -190,7 +192,7 @@ export interface QrCodeResponse {
 }
 
 export interface QrStatusResponse {
-  status: 'wait' | 'scaned' | 'confirmed' | 'expired' | 'scaned_but_redirect'
+  status: 'wait' | 'scaned' | 'confirmed' | 'expired' | 'scaned_but_redirect' | 'binded_redirect'
   bot_token?: string
   ilink_bot_id?: string
   ilink_user_id?: string

--- a/nodejs/src/protocol/types.ts
+++ b/nodejs/src/protocol/types.ts
@@ -192,7 +192,15 @@ export interface QrCodeResponse {
 }
 
 export interface QrStatusResponse {
-  status: 'wait' | 'scaned' | 'confirmed' | 'expired' | 'scaned_but_redirect' | 'binded_redirect'
+  status:
+    | 'wait'
+    | 'scaned'
+    | 'confirmed'
+    | 'expired'
+    | 'scaned_but_redirect'
+    | 'binded_redirect'
+    | 'need_verifycode'
+    | 'verify_code_blocked'
   bot_token?: string
   ilink_bot_id?: string
   ilink_user_id?: string

--- a/nodejs/tests/bot-agent.test.ts
+++ b/nodejs/tests/bot-agent.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest'
+import { DEFAULT_BOT_AGENT, sanitizeBotAgent } from '../src/protocol/bot-agent.js'
+
+describe('sanitizeBotAgent', () => {
+  it('falls back to default for empty input', () => {
+    expect(sanitizeBotAgent(undefined)).toBe(DEFAULT_BOT_AGENT)
+    expect(sanitizeBotAgent('')).toBe(DEFAULT_BOT_AGENT)
+    expect(sanitizeBotAgent('   ')).toBe(DEFAULT_BOT_AGENT)
+  })
+
+  it('accepts a single product', () => {
+    expect(sanitizeBotAgent('MyApp/1.2')).toBe('MyApp/1.2')
+  })
+
+  it('accepts a product with a comment', () => {
+    expect(sanitizeBotAgent('MyApp/1.2 (prod build)')).toBe('MyApp/1.2 (prod build)')
+  })
+
+  it('accepts multiple products', () => {
+    expect(sanitizeBotAgent('MyApp/1.2 (prod) Lib/0.3')).toBe('MyApp/1.2 (prod) Lib/0.3')
+  })
+
+  it('normalizes extra whitespace', () => {
+    expect(sanitizeBotAgent('  MyApp/1.2   Lib/0.3 ')).toBe('MyApp/1.2 Lib/0.3')
+  })
+
+  it('rejects invalid input wholesale', () => {
+    expect(sanitizeBotAgent('no-slash')).toBe(DEFAULT_BOT_AGENT)
+    expect(sanitizeBotAgent('bad name/1.0 !!!')).toBe(DEFAULT_BOT_AGENT)
+    expect(sanitizeBotAgent('(orphan comment)')).toBe(DEFAULT_BOT_AGENT)
+    expect(sanitizeBotAgent('App/1.0 (unclosed')).toBe(DEFAULT_BOT_AGENT)
+    expect(sanitizeBotAgent('App/1.0 (nested (comment))')).toBe(DEFAULT_BOT_AGENT)
+  })
+
+  it('rejects names or versions that are too long', () => {
+    expect(sanitizeBotAgent(`${'a'.repeat(33)}/1.0`)).toBe(DEFAULT_BOT_AGENT)
+    expect(sanitizeBotAgent(`App/${'1'.repeat(33)}`)).toBe(DEFAULT_BOT_AGENT)
+  })
+
+  it('rejects strings over the byte cap', () => {
+    const product = 'App/1.0 '
+    expect(sanitizeBotAgent(product.repeat(40).trim())).toBe(DEFAULT_BOT_AGENT)
+  })
+})

--- a/python/tests/test_bot_agent.py
+++ b/python/tests/test_bot_agent.py
@@ -1,0 +1,42 @@
+"""Tests for bot_agent sanitization."""
+
+from wechatbot.protocol import DEFAULT_BOT_AGENT, sanitize_bot_agent
+
+
+def test_empty_input_falls_back_to_default():
+    assert sanitize_bot_agent(None) == DEFAULT_BOT_AGENT
+    assert sanitize_bot_agent("") == DEFAULT_BOT_AGENT
+    assert sanitize_bot_agent("   ") == DEFAULT_BOT_AGENT
+
+
+def test_single_product():
+    assert sanitize_bot_agent("MyApp/1.2") == "MyApp/1.2"
+
+
+def test_product_with_comment():
+    assert sanitize_bot_agent("MyApp/1.2 (prod build)") == "MyApp/1.2 (prod build)"
+
+
+def test_multiple_products():
+    assert sanitize_bot_agent("MyApp/1.2 (prod) Lib/0.3") == "MyApp/1.2 (prod) Lib/0.3"
+
+
+def test_normalizes_whitespace():
+    assert sanitize_bot_agent("  MyApp/1.2   Lib/0.3 ") == "MyApp/1.2 Lib/0.3"
+
+
+def test_invalid_input_falls_back_wholesale():
+    assert sanitize_bot_agent("no-slash") == DEFAULT_BOT_AGENT
+    assert sanitize_bot_agent("bad name/1.0 !!!") == DEFAULT_BOT_AGENT
+    assert sanitize_bot_agent("(orphan comment)") == DEFAULT_BOT_AGENT
+    assert sanitize_bot_agent("App/1.0 (unclosed") == DEFAULT_BOT_AGENT
+    assert sanitize_bot_agent("App/1.0 (nested (comment))") == DEFAULT_BOT_AGENT
+
+
+def test_overlong_tokens_rejected():
+    assert sanitize_bot_agent("a" * 33 + "/1.0") == DEFAULT_BOT_AGENT
+    assert sanitize_bot_agent("App/" + "1" * 33) == DEFAULT_BOT_AGENT
+
+
+def test_over_byte_cap_rejected():
+    assert sanitize_bot_agent(("App/1.0 " * 40).strip()) == DEFAULT_BOT_AGENT

--- a/python/wechatbot/auth.py
+++ b/python/wechatbot/auth.py
@@ -57,6 +57,17 @@ async def clear_credentials(path: Path | None = None) -> None:
     target.unlink(missing_ok=True)
 
 
+async def _read_verify_code(is_retry: bool) -> str:
+    """Default pairing-code prompt: read a line from stdin."""
+    prompt = (
+        "Code mismatch — enter the pairing code shown in WeChat again: "
+        if is_retry
+        else "Enter the pairing code shown in WeChat on your phone: "
+    )
+    code = await asyncio.to_thread(input, prompt)
+    return code.strip()
+
+
 async def login(
     api: ILinkApi,
     *,
@@ -66,6 +77,7 @@ async def login(
     on_qr_url: Callable[[str], None] | None = None,
     on_scanned: Callable[[], None] | None = None,
     on_expired: Callable[[], None] | None = None,
+    on_verify_code: Callable[[bool], str] | None = None,
 ) -> Credentials:
     """QR code login. Returns stored credentials if available and force=False."""
     stored = await load_credentials(cred_path)
@@ -94,13 +106,19 @@ async def login(
 
         last_status = ""
         current_poll_base_url = FIXED_QR_BASE_URL
+        # Pairing code awaiting server verification (pair-code login flow)
+        pending_verify_code: str | None = None
         while True:
-            status = await api.poll_qr_status(current_poll_base_url, qr["qrcode"])
+            status = await api.poll_qr_status(
+                current_poll_base_url, qr["qrcode"], pending_verify_code
+            )
             current = status["status"]
 
             if current != last_status:
                 last_status = current
                 if current == "scaned":
+                    # A pending pairing code that leads back to scaned was accepted
+                    pending_verify_code = None
                     if on_scanned:
                         on_scanned()
                     else:
@@ -131,6 +149,25 @@ async def login(
                 )
                 await save_credentials(creds, cred_path)
                 return creds
+
+            # Pair-code challenge: ask the user for the digits shown in WeChat
+            if current == "need_verifycode":
+                is_retry = pending_verify_code is not None
+                if on_verify_code:
+                    pending_verify_code = on_verify_code(is_retry)
+                else:
+                    pending_verify_code = await _read_verify_code(is_retry)
+                continue  # Re-poll immediately with the code attached
+
+            # Too many wrong pairing codes: server blocked this QR — get a new one
+            if current == "verify_code_blocked":
+                print(
+                    "[wechatbot] Pairing code blocked after repeated mismatches "
+                    "— requesting new QR",
+                    file=sys.stderr,
+                )
+                pending_verify_code = None
+                break  # Outer loop requests a new QR (counts toward refresh limit)
 
             # Already bound to this client: reuse existing local credentials
             if current == "binded_redirect":

--- a/python/wechatbot/auth.py
+++ b/python/wechatbot/auth.py
@@ -68,10 +68,13 @@ async def login(
     on_expired: Callable[[], None] | None = None,
 ) -> Credentials:
     """QR code login. Returns stored credentials if available and force=False."""
-    if not force:
-        stored = await load_credentials(cred_path)
-        if stored:
-            return stored
+    stored = await load_credentials(cred_path)
+    if not force and stored:
+        return stored
+
+    # Send known local tokens so the server can answer binded_redirect
+    # instead of issuing a duplicate session for an already-bound bot.
+    local_token_list = [stored.token] if stored and stored.token else []
 
     qr_refresh_count = 0
     while True:
@@ -81,7 +84,7 @@ async def login(
                 f"QR code expired {MAX_QR_REFRESH_COUNT} times — login aborted"
             )
 
-        qr = await api.get_qr_code(FIXED_QR_BASE_URL)
+        qr = await api.get_qr_code(FIXED_QR_BASE_URL, local_token_list)
         qr_url = qr["qrcode_img_content"]
 
         if on_qr_url:
@@ -128,6 +131,19 @@ async def login(
                 )
                 await save_credentials(creds, cred_path)
                 return creds
+
+            # Already bound to this client: reuse existing local credentials
+            if current == "binded_redirect":
+                if stored:
+                    print(
+                        "[wechatbot] Bot already bound — reusing stored credentials",
+                        file=sys.stderr,
+                    )
+                    return stored
+                raise AuthError(
+                    "Server reports this bot is already bound to this client "
+                    "(binded_redirect), but no local credentials were found"
+                )
 
             # Handle IDC redirect
             if current == "scaned_but_redirect":

--- a/python/wechatbot/client.py
+++ b/python/wechatbot/client.py
@@ -77,6 +77,7 @@ class WeChatBot:
         on_scanned: Callable[[], None] | None = None,
         on_expired: Callable[[], None] | None = None,
         on_error: Callable[[Exception], None] | None = None,
+        on_verify_code: Callable[[bool], str] | None = None,
         bot_agent: str | None = None,
     ) -> None:
         self._base_url = base_url or DEFAULT_BASE_URL
@@ -85,6 +86,7 @@ class WeChatBot:
         self._on_scanned = on_scanned
         self._on_expired = on_expired
         self._on_error = on_error
+        self._on_verify_code = on_verify_code
 
         self._api = ILinkApi(bot_agent=bot_agent)
         self._credentials: Credentials | None = None
@@ -105,6 +107,7 @@ class WeChatBot:
             on_qr_url=self._on_qr_url,
             on_scanned=self._on_scanned,
             on_expired=self._on_expired,
+            on_verify_code=self._on_verify_code,
         )
         self._credentials = creds
         self._base_url = creds.base_url

--- a/python/wechatbot/client.py
+++ b/python/wechatbot/client.py
@@ -77,6 +77,7 @@ class WeChatBot:
         on_scanned: Callable[[], None] | None = None,
         on_expired: Callable[[], None] | None = None,
         on_error: Callable[[Exception], None] | None = None,
+        bot_agent: str | None = None,
     ) -> None:
         self._base_url = base_url or DEFAULT_BASE_URL
         self._cred_path = Path(cred_path) if cred_path else None
@@ -85,7 +86,7 @@ class WeChatBot:
         self._on_expired = on_expired
         self._on_error = on_error
 
-        self._api = ILinkApi()
+        self._api = ILinkApi(bot_agent=bot_agent)
         self._credentials: Credentials | None = None
         self._context_tokens: dict[str, str] = {}
         self._handlers: list[MessageHandler] = []

--- a/python/wechatbot/protocol.py
+++ b/python/wechatbot/protocol.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import base64
 import json
 import os
+import re
 import struct
 from importlib.metadata import version as pkg_version
 from typing import Any
@@ -67,8 +68,32 @@ def auth_headers(token: str) -> dict[str, str]:
     }
 
 
-def _base_info() -> dict[str, str]:
-    return {"channel_version": CHANNEL_VERSION}
+# Default bot_agent when none is configured or the configured value is invalid.
+DEFAULT_BOT_AGENT = f"WeChatBot/{CHANNEL_VERSION}"
+
+# Maximum length (bytes) of the sanitized bot_agent string.
+_BOT_AGENT_MAX_LEN = 256
+
+# UA-style grammar (matches openclaw-weixin):
+#   bot_agent = product *( SP product )
+#   product   = name "/" version [ SP "(" comment ")" ]
+_PRODUCT = r"[A-Za-z0-9_.\-]{1,32}/[A-Za-z0-9_.+\-]{1,32}(?: \([\x20-\x27\x2A-\x7E]{1,64}\))?"
+_BOT_AGENT_RE = re.compile(rf"^{_PRODUCT}(?: {_PRODUCT})*$")
+
+
+def sanitize_bot_agent(raw: str | None) -> str:
+    """Validate a user-supplied bot_agent into a wire-safe string.
+
+    Unlike upstream openclaw-weixin (which salvages the valid tokens out of a
+    partially invalid string), any invalid input falls back to
+    DEFAULT_BOT_AGENT wholesale — simpler and just as safe on the wire.
+    """
+    if not raw:
+        return DEFAULT_BOT_AGENT
+    normalized = " ".join(raw.split())
+    if not normalized or len(normalized.encode("utf-8")) > _BOT_AGENT_MAX_LEN:
+        return DEFAULT_BOT_AGENT
+    return normalized if _BOT_AGENT_RE.match(normalized) else DEFAULT_BOT_AGENT
 
 
 async def _parse_response(resp: aiohttp.ClientResponse, label: str) -> dict[str, Any]:
@@ -97,13 +122,28 @@ async def _parse_response(resp: aiohttp.ClientResponse, label: str) -> dict[str,
 class ILinkApi:
     """Low-level iLink API client. Each method maps 1:1 to an endpoint."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, bot_agent: str | None = None) -> None:
         self._timeout = aiohttp.ClientTimeout(total=45)
+        self._bot_agent = sanitize_bot_agent(bot_agent)
 
-    async def get_qr_code(self, base_url: str) -> dict[str, Any]:
+    def _base_info(self) -> dict[str, str]:
+        return {"channel_version": CHANNEL_VERSION, "bot_agent": self._bot_agent}
+
+    async def get_qr_code(
+        self, base_url: str, local_token_list: list[str] | None = None
+    ) -> dict[str, Any]:
+        """Request a login QR code.
+
+        local_token_list carries up to 10 known local bot tokens (newest
+        first) so the server can answer binded_redirect for an already-bound
+        bot instead of issuing a duplicate session.
+        """
         url = f"{base_url}/ilink/bot/get_bot_qrcode?bot_type=3"
+        body = {"local_token_list": local_token_list or []}
         async with aiohttp.ClientSession() as session:
-            async with session.get(url, headers=_common_headers()) as resp:
+            async with session.post(
+                url, headers=_common_headers(), json=body
+            ) as resp:
                 return await _parse_response(resp, "get_bot_qrcode")
 
     async def poll_qr_status(self, base_url: str, qrcode: str) -> dict[str, Any]:
@@ -117,13 +157,13 @@ class ILinkApi:
     async def get_updates(
         self, base_url: str, token: str, cursor: str
     ) -> dict[str, Any]:
-        body = {"get_updates_buf": cursor, "base_info": _base_info()}
+        body = {"get_updates_buf": cursor, "base_info": self._base_info()}
         return await self._post(base_url, "/ilink/bot/getupdates", token, body, 45)
 
     async def send_message(
         self, base_url: str, token: str, msg: dict[str, Any]
     ) -> dict[str, Any]:
-        body = {"msg": msg, "base_info": _base_info()}
+        body = {"msg": msg, "base_info": self._base_info()}
         return await self._post(base_url, "/ilink/bot/sendmessage", token, body)
 
     async def get_config(
@@ -132,7 +172,7 @@ class ILinkApi:
         body = {
             "ilink_user_id": user_id,
             "context_token": context_token,
-            "base_info": _base_info(),
+            "base_info": self._base_info(),
         }
         return await self._post(base_url, "/ilink/bot/getconfig", token, body)
 
@@ -148,7 +188,7 @@ class ILinkApi:
             "ilink_user_id": user_id,
             "typing_ticket": ticket,
             "status": status,
-            "base_info": _base_info(),
+            "base_info": self._base_info(),
         }
         return await self._post(base_url, "/ilink/bot/sendtyping", token, body)
 
@@ -207,7 +247,7 @@ class ILinkApi:
             "filesize": filesize,
             "no_need_thumb": no_need_thumb,
             "aeskey": aeskey,
-            "base_info": _base_info(),
+            "base_info": self._base_info(),
         }
         return await self._post(base_url, "/ilink/bot/getuploadurl", token, body)
 

--- a/python/wechatbot/protocol.py
+++ b/python/wechatbot/protocol.py
@@ -146,8 +146,17 @@ class ILinkApi:
             ) as resp:
                 return await _parse_response(resp, "get_bot_qrcode")
 
-    async def poll_qr_status(self, base_url: str, qrcode: str) -> dict[str, Any]:
+    async def poll_qr_status(
+        self, base_url: str, qrcode: str, verify_code: str | None = None
+    ) -> dict[str, Any]:
+        """Poll the QR scan status.
+
+        verify_code submits a pairing code after the server answered
+        need_verifycode (the digits shown in WeChat on the user's phone).
+        """
         url = f"{base_url}/ilink/bot/get_qrcode_status?qrcode={quote(qrcode, safe='')}"
+        if verify_code:
+            url += f"&verify_code={quote(verify_code, safe='')}"
         async with aiohttp.ClientSession() as session:
             async with session.get(
                 url, headers=_common_headers()

--- a/python/wechatbot/protocol.py
+++ b/python/wechatbot/protocol.py
@@ -203,12 +203,12 @@ class ILinkApi:
 
     async def notify_start(self, base_url: str, token: str) -> dict[str, Any]:
         """Notify the server that this client is starting (coming online)."""
-        body = {"base_info": _base_info()}
+        body = {"base_info": self._base_info()}
         return await self._post(base_url, "/ilink/bot/msg/notifystart", token, body)
 
     async def notify_stop(self, base_url: str, token: str) -> dict[str, Any]:
         """Notify the server that this client is stopping (going offline)."""
-        body = {"base_info": _base_info()}
+        body = {"base_info": self._base_info()}
         return await self._post(base_url, "/ilink/bot/msg/notifystop", token, body)
 
     @staticmethod

--- a/rust/src/bot.rs
+++ b/rust/src/bot.rs
@@ -19,6 +19,25 @@ use serde_json::json;
 /// Message handler callback type.
 pub type MessageHandler = Box<dyn Fn(&IncomingMessage) + Send + Sync>;
 
+/// Default pairing-code prompt: read a line from stdin without blocking the runtime.
+async fn read_verify_code_from_stdin(is_retry: bool) -> Result<String> {
+    tokio::task::spawn_blocking(move || -> Result<String> {
+        use std::io::{BufRead, Write};
+        let prompt = if is_retry {
+            "Code mismatch — enter the pairing code shown in WeChat again: "
+        } else {
+            "Enter the pairing code shown in WeChat on your phone: "
+        };
+        eprint!("{}", prompt);
+        std::io::stderr().flush().ok();
+        let mut line = String::new();
+        std::io::stdin().lock().read_line(&mut line)?;
+        Ok(line.trim().to_string())
+    })
+    .await
+    .map_err(|e| WeChatBotError::Auth(format!("pairing code prompt failed: {e}")))?
+}
+
 /// Bot configuration options.
 pub struct BotOptions {
     pub base_url: Option<String>,
@@ -29,6 +48,10 @@ pub struct BotOptions {
     /// `base_info.bot_agent` on every API request (e.g. "MyApp/1.2 (prod)").
     /// Invalid values fall back to `protocol::default_bot_agent()`.
     pub bot_agent: Option<String>,
+    /// Called when the server requires a pairing code (the digits shown in
+    /// WeChat on the user's phone). The argument is true when a previously
+    /// submitted code was rejected. Defaults to a stdin prompt.
+    pub on_verify_code: Option<Box<dyn Fn(bool) -> String + Send + Sync>>,
 }
 
 impl Default for BotOptions {
@@ -39,6 +62,7 @@ impl Default for BotOptions {
             on_qr_url: None,
             on_error: None,
             bot_agent: None,
+            on_verify_code: None,
         }
     }
 }
@@ -56,6 +80,7 @@ pub struct WeChatBot {
     stopped: RwLock<bool>,
     on_qr_url: Option<Box<dyn Fn(&str) + Send + Sync>>,
     on_error: Option<Box<dyn Fn(&WeChatBotError) + Send + Sync>>,
+    on_verify_code: Option<Box<dyn Fn(bool) -> String + Send + Sync>>,
 }
 
 impl WeChatBot {
@@ -76,6 +101,7 @@ impl WeChatBot {
             stopped: RwLock::new(false),
             on_qr_url: opts.on_qr_url,
             on_error: opts.on_error,
+            on_verify_code: opts.on_verify_code,
         }
     }
 
@@ -130,20 +156,49 @@ impl WeChatBot {
 
             let mut last_status = String::new();
             let mut current_poll_base_url = Self::FIXED_QR_BASE_URL.to_string();
+            // Pairing code awaiting server verification (pair-code login flow)
+            let mut pending_verify_code: Option<String> = None;
             loop {
                 let status = self
                     .client
-                    .poll_qr_status(&current_poll_base_url, &qr.qrcode)
+                    .poll_qr_status(
+                        &current_poll_base_url,
+                        &qr.qrcode,
+                        pending_verify_code.as_deref(),
+                    )
                     .await?;
 
                 if status.status != last_status {
                     last_status = status.status.clone();
                     match status.status.as_str() {
-                        "scaned" => info!("QR scanned — confirm in WeChat"),
+                        "scaned" => {
+                            // A pending pairing code that leads back to
+                            // `scaned` was accepted
+                            pending_verify_code = None;
+                            info!("QR scanned — confirm in WeChat");
+                        }
                         "expired" => warn!("QR expired — requesting new one"),
                         "confirmed" => info!("Login confirmed"),
                         _ => {}
                     }
+                }
+
+                // Pair-code challenge: ask the user for the digits shown in WeChat
+                if status.status == "need_verifycode" {
+                    let is_retry = pending_verify_code.is_some();
+                    let code = match self.on_verify_code {
+                        Some(ref cb) => cb(is_retry),
+                        None => read_verify_code_from_stdin(is_retry).await?,
+                    };
+                    pending_verify_code = Some(code);
+                    continue; // Re-poll immediately with the code attached
+                }
+
+                // Too many wrong pairing codes: server blocked this QR — get a new one
+                if status.status == "verify_code_blocked" {
+                    warn!("Pairing code blocked after repeated mismatches — requesting new QR");
+                    pending_verify_code = None;
+                    break; // Outer loop requests a new QR (counts toward refresh limit)
                 }
 
                 if status.status == "confirmed" {

--- a/rust/src/bot.rs
+++ b/rust/src/bot.rs
@@ -25,6 +25,10 @@ pub struct BotOptions {
     pub cred_path: Option<String>,
     pub on_qr_url: Option<Box<dyn Fn(&str) + Send + Sync>>,
     pub on_error: Option<Box<dyn Fn(&WeChatBotError) + Send + Sync>>,
+    /// UA-style identifier of the app driving this bot, sent as
+    /// `base_info.bot_agent` on every API request (e.g. "MyApp/1.2 (prod)").
+    /// Invalid values fall back to `protocol::default_bot_agent()`.
+    pub bot_agent: Option<String>,
 }
 
 impl Default for BotOptions {
@@ -34,6 +38,7 @@ impl Default for BotOptions {
             cred_path: None,
             on_qr_url: None,
             on_error: None,
+            bot_agent: None,
         }
     }
 }
@@ -57,7 +62,7 @@ impl WeChatBot {
     /// Create a new bot instance.
     pub fn new(opts: BotOptions) -> Self {
         Self {
-            client: Arc::new(ILinkClient::new()),
+            client: Arc::new(ILinkClient::with_bot_agent(opts.bot_agent.as_deref())),
             cdn: CdnClient::new(),
             credentials: RwLock::new(None),
             context_tokens: RwLock::new(HashMap::new()),
@@ -83,14 +88,23 @@ impl WeChatBot {
     pub async fn login(&self, force: bool) -> Result<Credentials> {
         let base_url = self.base_url.read().await.clone();
 
+        let stored = self.load_credentials().await?;
         if !force {
-            if let Some(creds) = self.load_credentials().await? {
+            if let Some(creds) = stored.clone() {
                 *self.credentials.write().await = Some(creds.clone());
                 *self.base_url.write().await = creds.base_url.clone();
                 info!("Loaded stored credentials for {}", creds.user_id);
                 return Ok(creds);
             }
         }
+
+        // Send known local tokens so the server can answer `binded_redirect`
+        // instead of issuing a duplicate session for an already-bound bot.
+        let local_token_list: Vec<String> = stored
+            .as_ref()
+            .filter(|c| !c.token.is_empty())
+            .map(|c| vec![c.token.clone()])
+            .unwrap_or_default();
 
         // QR code login flow
         let mut qr_refresh_count = 0u32;
@@ -103,7 +117,10 @@ impl WeChatBot {
                 )));
             }
 
-            let qr = self.client.get_qr_code(Self::FIXED_QR_BASE_URL).await?;
+            let qr = self
+                .client
+                .get_qr_code(Self::FIXED_QR_BASE_URL, &local_token_list)
+                .await?;
 
             if let Some(ref cb) = self.on_qr_url {
                 cb(&qr.qrcode_img_content);
@@ -144,6 +161,21 @@ impl WeChatBot {
                     *self.credentials.write().await = Some(creds.clone());
                     *self.base_url.write().await = creds.base_url.clone();
                     return Ok(creds);
+                }
+
+                // Already bound to this client: reuse existing local credentials
+                if status.status == "binded_redirect" {
+                    if let Some(creds) = stored.clone() {
+                        info!("Bot already bound — reusing stored credentials");
+                        *self.credentials.write().await = Some(creds.clone());
+                        *self.base_url.write().await = creds.base_url.clone();
+                        return Ok(creds);
+                    }
+                    return Err(WeChatBotError::Auth(
+                        "server reports this bot is already bound to this client \
+                         (binded_redirect), but no local credentials were found"
+                            .into(),
+                    ));
                 }
 
                 // Handle IDC redirect

--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -260,12 +260,24 @@ impl ILinkClient {
         Ok(resp.json().await?)
     }
 
-    pub async fn poll_qr_status(&self, base_url: &str, qrcode: &str) -> Result<QrStatusResponse> {
-        let url = format!(
+    /// Poll the QR scan status.
+    ///
+    /// `verify_code` submits a pairing code after the server answered
+    /// `need_verifycode` (the digits shown in WeChat on the user's phone).
+    pub async fn poll_qr_status(
+        &self,
+        base_url: &str,
+        qrcode: &str,
+        verify_code: Option<&str>,
+    ) -> Result<QrStatusResponse> {
+        let mut url = format!(
             "{}/ilink/bot/get_qrcode_status?qrcode={}",
             base_url,
             urlencoding::encode(qrcode)
         );
+        if let Some(code) = verify_code {
+            url.push_str(&format!("&verify_code={}", urlencoding::encode(code)));
+        }
         let resp = self
             .http
             .get(&url)

--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -30,6 +30,139 @@ fn build_client_version() -> String {
     num.to_string()
 }
 
+/// Default `bot_agent` when none is configured or the configured value is invalid.
+pub fn default_bot_agent() -> String {
+    format!("WeChatBot/{}", CHANNEL_VERSION)
+}
+
+/// Maximum length (bytes) of the sanitized `bot_agent` string.
+const BOT_AGENT_MAX_LEN: usize = 256;
+
+fn is_valid_product(tok: &str) -> bool {
+    let Some((name, version)) = tok.split_once('/') else {
+        return false;
+    };
+    (1..=32).contains(&name.len())
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b'-'))
+        && (1..=32).contains(&version.len())
+        && version
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'_' | b'.' | b'+' | b'-'))
+}
+
+/// Validate a user-supplied `bot_agent` into a wire-safe string.
+///
+/// UA-style grammar (matches openclaw-weixin):
+///   bot_agent = product *( SP product )
+///   product   = name "/" version [ SP "(" comment ")" ]
+///   name      = 1*32( ALPHA / DIGIT / "_" / "." / "-" )
+///   version   = 1*32( ALPHA / DIGIT / "_" / "." / "+" / "-" )
+///   comment   = 1*64( printable ASCII minus "(" ")" )
+///
+/// Unlike upstream openclaw-weixin (which salvages the valid tokens out of a
+/// partially invalid string), any invalid input falls back to
+/// `default_bot_agent()` wholesale — simpler and just as safe on the wire.
+pub fn sanitize_bot_agent(raw: Option<&str>) -> String {
+    let default = default_bot_agent();
+    let Some(raw) = raw else { return default };
+
+    // Normalize whitespace, keeping multi-word "(comment)" tokens intact.
+    let mut tokens: Vec<String> = Vec::new();
+    let mut in_comment = false;
+    for word in raw.split_whitespace() {
+        if in_comment {
+            let last = tokens.last_mut().expect("comment follows a token");
+            last.push(' ');
+            last.push_str(word);
+            in_comment = !word.ends_with(')');
+        } else {
+            tokens.push(word.to_string());
+            in_comment = word.starts_with('(') && !word.ends_with(')');
+        }
+    }
+    if tokens.is_empty() || in_comment {
+        return default;
+    }
+
+    // Validate: each token is a product, or a "(comment)" directly after one.
+    let mut prev_was_product = false;
+    for tok in &tokens {
+        if tok.starts_with('(') && tok.ends_with(')') && tok.len() >= 2 {
+            let inner = &tok[1..tok.len() - 1];
+            let ok = prev_was_product
+                && (1..=64).contains(&inner.len())
+                && inner
+                    .bytes()
+                    .all(|b| (0x20..=0x7e).contains(&b) && b != b'(' && b != b')');
+            if !ok {
+                return default;
+            }
+            prev_was_product = false;
+        } else if is_valid_product(tok) {
+            prev_was_product = true;
+        } else {
+            return default;
+        }
+    }
+
+    let joined = tokens.join(" ");
+    if joined.len() > BOT_AGENT_MAX_LEN {
+        return default;
+    }
+    joined
+}
+
+#[cfg(test)]
+mod bot_agent_tests {
+    use super::*;
+
+    #[test]
+    fn empty_input_falls_back_to_default() {
+        assert_eq!(sanitize_bot_agent(None), default_bot_agent());
+        assert_eq!(sanitize_bot_agent(Some("")), default_bot_agent());
+        assert_eq!(sanitize_bot_agent(Some("   ")), default_bot_agent());
+    }
+
+    #[test]
+    fn valid_agents_pass_through() {
+        assert_eq!(sanitize_bot_agent(Some("MyApp/1.2")), "MyApp/1.2");
+        assert_eq!(
+            sanitize_bot_agent(Some("MyApp/1.2 (prod build)")),
+            "MyApp/1.2 (prod build)"
+        );
+        assert_eq!(
+            sanitize_bot_agent(Some("MyApp/1.2 (prod) Lib/0.3")),
+            "MyApp/1.2 (prod) Lib/0.3"
+        );
+        assert_eq!(
+            sanitize_bot_agent(Some("  MyApp/1.2   Lib/0.3 ")),
+            "MyApp/1.2 Lib/0.3"
+        );
+    }
+
+    #[test]
+    fn invalid_agents_fall_back_wholesale() {
+        for bad in [
+            "no-slash",
+            "bad name/1.0 !!!",
+            "(orphan comment)",
+            "App/1.0 (unclosed",
+            "App/1.0 (nested (comment))",
+        ] {
+            assert_eq!(sanitize_bot_agent(Some(bad)), default_bot_agent(), "{bad}");
+        }
+        let long_name = format!("{}/1.0", "a".repeat(33));
+        assert_eq!(sanitize_bot_agent(Some(&long_name)), default_bot_agent());
+        let over_cap = "App/1.0 ".repeat(40);
+        assert_eq!(
+            sanitize_bot_agent(Some(over_cap.trim())),
+            default_bot_agent()
+        );
+    }
+}
+
 /// Generate the X-WECHAT-UIN header value.
 pub fn random_wechat_uin() -> String {
     let mut buf = [0u8; 4];
@@ -80,25 +213,48 @@ pub struct GetConfigResponse {
 #[derive(Debug)]
 pub struct ILinkClient {
     http: Client,
+    bot_agent: String,
 }
 
 impl ILinkClient {
     pub fn new() -> Self {
+        Self::with_bot_agent(None)
+    }
+
+    /// Create a client with a custom `bot_agent` (sent as `base_info.bot_agent`
+    /// on every API request). Invalid values fall back to `default_bot_agent()`.
+    pub fn with_bot_agent(bot_agent: Option<&str>) -> Self {
         Self {
             http: Client::builder()
                 .timeout(Duration::from_secs(45))
                 .build()
                 .unwrap(),
+            bot_agent: sanitize_bot_agent(bot_agent),
         }
     }
 
-    pub async fn get_qr_code(&self, base_url: &str) -> Result<QrCodeResponse> {
+    fn base_info(&self) -> Value {
+        json!({ "channel_version": CHANNEL_VERSION, "bot_agent": self.bot_agent })
+    }
+
+    /// Request a login QR code.
+    ///
+    /// `local_token_list` carries up to 10 known local bot tokens (newest
+    /// first) so the server can answer `binded_redirect` for an already-bound
+    /// bot instead of issuing a duplicate session.
+    pub async fn get_qr_code(
+        &self,
+        base_url: &str,
+        local_token_list: &[String],
+    ) -> Result<QrCodeResponse> {
         let url = format!("{}/ilink/bot/get_bot_qrcode?bot_type=3", base_url);
         let resp = self
             .http
-            .get(&url)
+            .post(&url)
+            .header("Content-Type", "application/json")
             .header("iLink-App-Id", ILINK_APP_ID)
             .header("iLink-App-ClientVersion", build_client_version())
+            .json(&json!({ "local_token_list": local_token_list }))
             .send()
             .await?;
         Ok(resp.json().await?)
@@ -128,7 +284,7 @@ impl ILinkClient {
     ) -> Result<GetUpdatesResponse> {
         let body = json!({
             "get_updates_buf": cursor,
-            "base_info": { "channel_version": CHANNEL_VERSION }
+            "base_info": self.base_info()
         });
         let resp = self
             .api_post(base_url, "/ilink/bot/getupdates", token, &body, 45)
@@ -151,7 +307,7 @@ impl ILinkClient {
     pub async fn send_message(&self, base_url: &str, token: &str, msg: &Value) -> Result<()> {
         let body = json!({
             "msg": msg,
-            "base_info": { "channel_version": CHANNEL_VERSION }
+            "base_info": self.base_info()
         });
         self.api_post(base_url, "/ilink/bot/sendmessage", token, &body, 15)
             .await?;
@@ -168,7 +324,7 @@ impl ILinkClient {
         let body = json!({
             "ilink_user_id": user_id,
             "context_token": context_token,
-            "base_info": { "channel_version": CHANNEL_VERSION }
+            "base_info": self.base_info()
         });
         let resp = self
             .api_post(base_url, "/ilink/bot/getconfig", token, &body, 15)
@@ -188,7 +344,7 @@ impl ILinkClient {
             "ilink_user_id": user_id,
             "typing_ticket": ticket,
             "status": status,
-            "base_info": { "channel_version": CHANNEL_VERSION }
+            "base_info": self.base_info()
         });
         self.api_post(base_url, "/ilink/bot/sendtyping", token, &body, 15)
             .await?;
@@ -302,7 +458,7 @@ impl ILinkClient {
             "filesize": params.filesize,
             "no_need_thumb": params.no_need_thumb,
             "aeskey": params.aeskey,
-            "base_info": { "channel_version": CHANNEL_VERSION }
+            "base_info": self.base_info()
         });
         let resp = self
             .api_post(base_url, "/ilink/bot/getuploadurl", token, &body, 15)

--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -365,7 +365,7 @@ impl ILinkClient {
 
     /// Notify the server that this client is starting (coming online).
     pub async fn notify_start(&self, base_url: &str, token: &str) -> Result<()> {
-        let body = json!({ "base_info": { "channel_version": CHANNEL_VERSION } });
+        let body = json!({ "base_info": self.base_info() });
         self.api_post(base_url, "/ilink/bot/msg/notifystart", token, &body, 15)
             .await?;
         Ok(())
@@ -373,7 +373,7 @@ impl ILinkClient {
 
     /// Notify the server that this client is stopping (going offline).
     pub async fn notify_stop(&self, base_url: &str, token: &str) -> Result<()> {
-        let body = json!({ "base_info": { "channel_version": CHANNEL_VERSION } });
+        let body = json!({ "base_info": self.base_info() });
         self.api_post(base_url, "/ilink/bot/msg/notifystop", token, &body, 15)
             .await?;
         Ok(())


### PR DESCRIPTION
## Summary

Part 2 of 3 porting upstream [openclaw-weixin](https://github.com/Tencent/openclaw-weixin) v2.1.7 → v2.4.6 protocol changes (part 1: #85). Ports the v2.3.1 protocol additions to all four SDKs:

### `base_info.bot_agent`
Every authorized POST now carries a UA-style identifier of the app driving the bot (`product *( SP product )`, product = `name "/" version [ SP "(" comment ")" ]`, max 256 bytes). Configurable per SDK (`botAgent` option in Node, `bot_agent` in Python/Rust, `Options.BotAgent` in Go); defaults to `WeChatBot/<version>`.

**Deliberate divergence from upstream**: upstream salvages the valid tokens out of a partially invalid string; we fall back to the default wholesale. Simpler to implement identically across 4 languages, and equally wire-safe. Sanitizer covered by tests in all four SDKs.

### `local_token_list` on QR fetch
`get_bot_qrcode` changes from GET to POST, carrying known local bot tokens so the server can recognize an already-bound bot instead of issuing a duplicate session. Our SDKs store a single credential, so the list is 0 or 1 tokens.

### `binded_redirect` QR status
New status meaning "this bot is already bound to this client" (matched via `local_token_list`). Treated as a successful no-op: stored local credentials are reused. If none exist, a clear auth error is raised instead of polling forever. Upstream shipped this to fix installers misreporting a successful state as a failed login (their v2.4.3 fix).

`docs/protocol.md` updated for all three changes.

## Test plan

- [x] Node: `tsc --noEmit` + vitest (77 passed, incl. 8 new sanitizer tests)
- [x] Go: `go build ./... && go vet ./... && go test ./...` (incl. new sanitizer table test)
- [x] Rust: `cargo test` (49 unit + 2 doc, incl. new sanitizer tests) + `cargo fmt --check` clean on changed code
- [x] Python: pytest (30 passed, incl. 8 new sanitizer tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)