### PR TITLE
feat: add pair-code login flow to all SDKs

### DIFF
--- a/docs/protocol.md
+++ b/docs/protocol.md
@@ -17,14 +17,19 @@ a duplicate session.
 
 ### Step 2: Poll Status
 ```
-GET /ilink/bot/get_qrcode_status?qrcode=<token>
+GET /ilink/bot/get_qrcode_status?qrcode=<token>[&verify_code=<digits>]
 Headers: { "iLink-App-ClientVersion": "1" }
-→ { status: "wait" | "scaned" | "confirmed" | "expired" | "scaned_but_redirect" | "binded_redirect",
+→ { status: "wait" | "scaned" | "confirmed" | "expired" | "scaned_but_redirect"
+          | "binded_redirect" | "need_verifycode" | "verify_code_blocked",
     bot_token?, ilink_bot_id?, ilink_user_id?, baseurl?, redirect_host? }
 ```
 - `scaned_but_redirect`: switch polling to `https://<redirect_host>` (IDC redirect)
 - `binded_redirect`: the scanned bot is already bound to this client (matched via
   `local_token_list`) — treat as success and reuse existing local credentials
+- `need_verifycode`: pair-code challenge — prompt the user for the digits shown in
+  WeChat on their phone and re-poll with `&verify_code=`. Getting `need_verifycode`
+  again means the code was wrong (re-prompt); getting `scaned` means it was accepted.
+- `verify_code_blocked`: too many wrong codes — this QR is dead, request a new one
 
 ## Common Headers (all POST requests)
 ```

--- a/golang/bot.go
+++ b/golang/bot.go
@@ -35,6 +35,10 @@ type Options struct {
 	OnScanned    func()
 	OnExpired    func()
 	OnError      func(err error)
+	// OnVerifyCode is called when the server requires a pairing code (the
+	// digits shown in WeChat on the user's phone). isRetry is true when a
+	// previously submitted code was rejected. Defaults to a stdin prompt.
+	OnVerifyCode func(isRetry bool) (string, error)
 	// BotAgent identifies the app driving this bot, sent as base_info.bot_agent
 	// on every API request (e.g. "MyApp/1.2 (prod)"). Invalid values fall back
 	// to protocol.DefaultBotAgent.
@@ -77,9 +81,10 @@ func (b *Bot) Login(ctx context.Context, force bool) (*Credentials, error) {
 		BaseURL:   b.opts.BaseURL,
 		CredPath:  b.opts.CredPath,
 		Force:     force,
-		OnQRURL:   b.opts.OnQRURL,
-		OnScanned: b.opts.OnScanned,
-		OnExpired: b.opts.OnExpired,
+		OnQRURL:      b.opts.OnQRURL,
+		OnScanned:    b.opts.OnScanned,
+		OnExpired:    b.opts.OnExpired,
+		OnVerifyCode: b.opts.OnVerifyCode,
 	})
 	if err != nil {
 		return nil, err

--- a/golang/internal/auth/login.go
+++ b/golang/internal/auth/login.go
@@ -2,11 +2,13 @@
 package auth
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/corespeed-io/wechatbot/golang/internal/protocol"
@@ -75,6 +77,25 @@ type LoginOptions struct {
 	OnQRURL   func(url string)
 	OnScanned func()
 	OnExpired func()
+	// OnVerifyCode is called when the server requires a pairing code (the
+	// digits shown in WeChat on the user's phone). isRetry is true when a
+	// previously submitted code was rejected. Defaults to a stdin prompt.
+	OnVerifyCode func(isRetry bool) (string, error)
+}
+
+// readVerifyCode is the default pairing-code prompt: read a line from stdin.
+func readVerifyCode(isRetry bool) (string, error) {
+	prompt := "Enter the pairing code shown in WeChat on your phone: "
+	if isRetry {
+		prompt = "Code mismatch — enter the pairing code shown in WeChat again: "
+	}
+	fmt.Fprint(os.Stderr, prompt)
+	reader := bufio.NewReader(os.Stdin)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(line), nil
 }
 
 const (
@@ -123,8 +144,10 @@ func Login(ctx context.Context, client *protocol.Client, opts LoginOptions) (*Cr
 
 		lastStatus := ""
 		currentPollBaseURL := fixedQRBaseURL
+		// Pairing code awaiting server verification (pair-code login flow)
+		pendingVerifyCode := ""
 		for {
-			status, err := client.PollQRStatus(ctx, currentPollBaseURL, qr.QRCode)
+			status, err := client.PollQRStatus(ctx, currentPollBaseURL, qr.QRCode, pendingVerifyCode)
 			if err != nil {
 				return nil, fmt.Errorf("poll QR status: %w", err)
 			}
@@ -133,6 +156,8 @@ func Login(ctx context.Context, client *protocol.Client, opts LoginOptions) (*Cr
 				lastStatus = status.Status
 				switch status.Status {
 				case "scaned":
+					// A pending pairing code that leads back to scaned was accepted
+					pendingVerifyCode = ""
 					if opts.OnScanned != nil {
 						opts.OnScanned()
 					} else {
@@ -168,6 +193,28 @@ func Login(ctx context.Context, client *protocol.Client, opts LoginOptions) (*Cr
 					fmt.Fprintf(os.Stderr, "[wechatbot] Warning: could not save credentials: %v\n", err)
 				}
 				return creds, nil
+			}
+
+			// Pair-code challenge: ask the user for the digits shown in WeChat
+			if status.Status == "need_verifycode" {
+				isRetry := pendingVerifyCode != ""
+				prompt := opts.OnVerifyCode
+				if prompt == nil {
+					prompt = readVerifyCode
+				}
+				code, err := prompt(isRetry)
+				if err != nil {
+					return nil, fmt.Errorf("read pairing code: %w", err)
+				}
+				pendingVerifyCode = code
+				continue // Re-poll immediately with the code attached
+			}
+
+			// Too many wrong pairing codes: server blocked this QR — get a new one
+			if status.Status == "verify_code_blocked" {
+				fmt.Fprintln(os.Stderr, "[wechatbot] Pairing code blocked after repeated mismatches — requesting new QR")
+				pendingVerifyCode = ""
+				break // Outer loop requests a new QR (counts toward refresh limit)
 			}
 
 			// Already bound to this client: reuse existing local credentials

--- a/golang/internal/protocol/api.go
+++ b/golang/internal/protocol/api.go
@@ -130,7 +130,7 @@ type QRCodeResponse struct {
 
 // QRStatusResponse from get_qrcode_status.
 type QRStatusResponse struct {
-	Status       string `json:"status"` // wait, scaned, confirmed, expired, scaned_but_redirect, binded_redirect
+	Status       string `json:"status"` // wait, scaned, confirmed, expired, scaned_but_redirect, binded_redirect, need_verifycode, verify_code_blocked
 	BotToken     string `json:"bot_token,omitempty"`
 	BotID        string `json:"ilink_bot_id,omitempty"`
 	UserID       string `json:"ilink_user_id,omitempty"`
@@ -182,8 +182,14 @@ func (c *Client) GetQRCode(ctx context.Context, baseURL string, localTokenList [
 }
 
 // PollQRStatus polls the QR code scan status.
-func (c *Client) PollQRStatus(ctx context.Context, baseURL, qrcode string) (*QRStatusResponse, error) {
+//
+// verifyCode submits a pairing code after the server answered need_verifycode
+// (the digits shown in WeChat on the user's phone). Pass "" when none.
+func (c *Client) PollQRStatus(ctx context.Context, baseURL, qrcode, verifyCode string) (*QRStatusResponse, error) {
 	u := baseURL + "/ilink/bot/get_qrcode_status?qrcode=" + url.QueryEscape(qrcode)
+	if verifyCode != "" {
+		u += "&verify_code=" + url.QueryEscape(verifyCode)
+	}
 	req, _ := http.NewRequestWithContext(ctx, "GET", u, nil)
 	for k, v := range CommonHeaders() {
 		req.Header[k] = v

--- a/nodejs/src/auth/authenticator.ts
+++ b/nodejs/src/auth/authenticator.ts
@@ -1,3 +1,4 @@
+import { createInterface } from 'node:readline/promises'
 import { setTimeout as delay } from 'node:timers/promises'
 import { AuthError } from '../core/errors.js'
 import type { Logger } from '../logger/types.js'
@@ -102,14 +103,21 @@ export class Authenticator {
       let lastStatus: string | undefined
       // Current polling URL; may be updated on IDC redirect
       let currentPollBaseUrl = FIXED_QR_BASE_URL
+      // Pairing code awaiting server verification (pair-code login flow)
+      let pendingVerifyCode: string | undefined
 
       for (;;) {
-        const status = await this.api.pollQrStatus(currentPollBaseUrl, qr.qrcode)
+        const status = await this.api.pollQrStatus(currentPollBaseUrl, qr.qrcode, pendingVerifyCode)
 
         if (status.status !== lastStatus) {
           lastStatus = status.status
 
           if (status.status === 'scaned') {
+            // A pending pairing code that leads back to `scaned` was accepted
+            if (pendingVerifyCode) {
+              this.logger.info('Pairing code accepted')
+              pendingVerifyCode = undefined
+            }
             this.logger.info('QR scanned — confirm in WeChat')
             callbacks?.onScanned?.()
           } else if (status.status === 'expired') {
@@ -142,6 +150,20 @@ export class Authenticator {
           return credentials
         }
 
+        // Pair-code challenge: ask the user for the digits shown in WeChat
+        if (status.status === 'need_verifycode') {
+          const isRetry = pendingVerifyCode !== undefined
+          pendingVerifyCode = await this.promptVerifyCode(isRetry, callbacks)
+          continue // Re-poll immediately with the code attached
+        }
+
+        // Too many wrong pairing codes: server blocked this QR — request a new one
+        if (status.status === 'verify_code_blocked') {
+          this.logger.warn('Pairing code blocked after repeated mismatches — requesting new QR')
+          pendingVerifyCode = undefined
+          break // Outer loop will request a new QR (counts toward the refresh limit)
+        }
+
         // Already bound to this client: reuse existing local credentials
         if (status.status === 'binded_redirect') {
           if (stored) {
@@ -172,6 +194,29 @@ export class Authenticator {
 
         await delay(QR_POLL_INTERVAL_MS)
       }
+    }
+  }
+
+  /**
+   * Obtain a pairing code from the developer callback, or fall back to a
+   * stdin prompt.
+   */
+  private async promptVerifyCode(
+    isRetry: boolean,
+    callbacks?: QrLoginCallbacks,
+  ): Promise<string> {
+    if (callbacks?.onVerifyCode) {
+      return callbacks.onVerifyCode(isRetry)
+    }
+
+    const prompt = isRetry
+      ? 'Code mismatch — enter the pairing code shown in WeChat again: '
+      : 'Enter the pairing code shown in WeChat on your phone: '
+    const rl = createInterface({ input: process.stdin, output: process.stdout })
+    try {
+      return (await rl.question(prompt)).trim()
+    } finally {
+      rl.close()
     }
   }
 }

--- a/nodejs/src/auth/types.ts
+++ b/nodejs/src/auth/types.ts
@@ -13,4 +13,10 @@ export interface QrLoginCallbacks {
   onScanned?: () => void
   /** Called when the QR code has expired and a new one will be requested. */
   onExpired?: () => void
+  /**
+   * Called when the server requires a pairing code (the digits shown in
+   * WeChat on the user's phone). `isRetry` is true when a previously
+   * submitted code was rejected. Defaults to a stdin prompt.
+   */
+  onVerifyCode?: (isRetry: boolean) => string | Promise<string>
 }

--- a/nodejs/src/protocol/api.ts
+++ b/nodejs/src/protocol/api.ts
@@ -54,12 +54,21 @@ export class ILinkApi {
     )
   }
 
-  async pollQrStatus(baseUrl: string, qrcode: string): Promise<QrStatusResponse> {
-    return this.http.apiGet<QrStatusResponse>(
-      baseUrl,
-      `/ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`,
-      buildCommonHeaders(),
-    )
+  /**
+   * Poll the QR scan status.
+   * `verifyCode` submits a pairing code after the server answered
+   * `need_verifycode` (the digits shown in WeChat on the user's phone).
+   */
+  async pollQrStatus(
+    baseUrl: string,
+    qrcode: string,
+    verifyCode?: string,
+  ): Promise<QrStatusResponse> {
+    let path = `/ilink/bot/get_qrcode_status?qrcode=${encodeURIComponent(qrcode)}`
+    if (verifyCode) {
+      path += `&verify_code=${encodeURIComponent(verifyCode)}`
+    }
+    return this.http.apiGet<QrStatusResponse>(baseUrl, path, buildCommonHeaders())
   }
 
   // ── Messages ──────────────────────────────────────────────────────────

--- a/nodejs/src/protocol/types.ts
+++ b/nodejs/src/protocol/types.ts
@@ -192,7 +192,15 @@ export interface QrCodeResponse {
 }
 
 export interface QrStatusResponse {
-  status: 'wait' | 'scaned' | 'confirmed' | 'expired' | 'scaned_but_redirect' | 'binded_redirect'
+  status:
+    | 'wait'
+    | 'scaned'
+    | 'confirmed'
+    | 'expired'
+    | 'scaned_but_redirect'
+    | 'binded_redirect'
+    | 'need_verifycode'
+    | 'verify_code_blocked'
   bot_token?: string
   ilink_bot_id?: string
   ilink_user_id?: string

--- a/python/wechatbot/auth.py
+++ b/python/wechatbot/auth.py
@@ -57,6 +57,17 @@ async def clear_credentials(path: Path | None = None) -> None:
     target.unlink(missing_ok=True)
 
 
+async def _read_verify_code(is_retry: bool) -> str:
+    """Default pairing-code prompt: read a line from stdin."""
+    prompt = (
+        "Code mismatch — enter the pairing code shown in WeChat again: "
+        if is_retry
+        else "Enter the pairing code shown in WeChat on your phone: "
+    )
+    code = await asyncio.to_thread(input, prompt)
+    return code.strip()
+
+
 async def login(
     api: ILinkApi,
     *,
@@ -66,6 +77,7 @@ async def login(
     on_qr_url: Callable[[str], None] | None = None,
     on_scanned: Callable[[], None] | None = None,
     on_expired: Callable[[], None] | None = None,
+    on_verify_code: Callable[[bool], str] | None = None,
 ) -> Credentials:
     """QR code login. Returns stored credentials if available and force=False."""
     stored = await load_credentials(cred_path)
@@ -94,13 +106,19 @@ async def login(
 
         last_status = ""
         current_poll_base_url = FIXED_QR_BASE_URL
+        # Pairing code awaiting server verification (pair-code login flow)
+        pending_verify_code: str | None = None
         while True:
-            status = await api.poll_qr_status(current_poll_base_url, qr["qrcode"])
+            status = await api.poll_qr_status(
+                current_poll_base_url, qr["qrcode"], pending_verify_code
+            )
             current = status["status"]
 
             if current != last_status:
                 last_status = current
                 if current == "scaned":
+                    # A pending pairing code that leads back to scaned was accepted
+                    pending_verify_code = None
                     if on_scanned:
                         on_scanned()
                     else:
@@ -131,6 +149,25 @@ async def login(
                 )
                 await save_credentials(creds, cred_path)
                 return creds
+
+            # Pair-code challenge: ask the user for the digits shown in WeChat
+            if current == "need_verifycode":
+                is_retry = pending_verify_code is not None
+                if on_verify_code:
+                    pending_verify_code = on_verify_code(is_retry)
+                else:
+                    pending_verify_code = await _read_verify_code(is_retry)
+                continue  # Re-poll immediately with the code attached
+
+            # Too many wrong pairing codes: server blocked this QR — get a new one
+            if current == "verify_code_blocked":
+                print(
+                    "[wechatbot] Pairing code blocked after repeated mismatches "
+                    "— requesting new QR",
+                    file=sys.stderr,
+                )
+                pending_verify_code = None
+                break  # Outer loop requests a new QR (counts toward refresh limit)
 
             # Already bound to this client: reuse existing local credentials
             if current == "binded_redirect":

--- a/python/wechatbot/client.py
+++ b/python/wechatbot/client.py
@@ -77,6 +77,7 @@ class WeChatBot:
         on_scanned: Callable[[], None] | None = None,
         on_expired: Callable[[], None] | None = None,
         on_error: Callable[[Exception], None] | None = None,
+        on_verify_code: Callable[[bool], str] | None = None,
         bot_agent: str | None = None,
     ) -> None:
         self._base_url = base_url or DEFAULT_BASE_URL
@@ -85,6 +86,7 @@ class WeChatBot:
         self._on_scanned = on_scanned
         self._on_expired = on_expired
         self._on_error = on_error
+        self._on_verify_code = on_verify_code
 
         self._api = ILinkApi(bot_agent=bot_agent)
         self._credentials: Credentials | None = None
@@ -105,6 +107,7 @@ class WeChatBot:
             on_qr_url=self._on_qr_url,
             on_scanned=self._on_scanned,
             on_expired=self._on_expired,
+            on_verify_code=self._on_verify_code,
         )
         self._credentials = creds
         self._base_url = creds.base_url

--- a/python/wechatbot/protocol.py
+++ b/python/wechatbot/protocol.py
@@ -146,8 +146,17 @@ class ILinkApi:
             ) as resp:
                 return await _parse_response(resp, "get_bot_qrcode")
 
-    async def poll_qr_status(self, base_url: str, qrcode: str) -> dict[str, Any]:
+    async def poll_qr_status(
+        self, base_url: str, qrcode: str, verify_code: str | None = None
+    ) -> dict[str, Any]:
+        """Poll the QR scan status.
+
+        verify_code submits a pairing code after the server answered
+        need_verifycode (the digits shown in WeChat on the user's phone).
+        """
         url = f"{base_url}/ilink/bot/get_qrcode_status?qrcode={quote(qrcode, safe='')}"
+        if verify_code:
+            url += f"&verify_code={quote(verify_code, safe='')}"
         async with aiohttp.ClientSession() as session:
             async with session.get(
                 url, headers=_common_headers()

--- a/rust/src/bot.rs
+++ b/rust/src/bot.rs
@@ -19,6 +19,25 @@ use serde_json::json;
 /// Message handler callback type.
 pub type MessageHandler = Box<dyn Fn(&IncomingMessage) + Send + Sync>;
 
+/// Default pairing-code prompt: read a line from stdin without blocking the runtime.
+async fn read_verify_code_from_stdin(is_retry: bool) -> Result<String> {
+    tokio::task::spawn_blocking(move || -> Result<String> {
+        use std::io::{BufRead, Write};
+        let prompt = if is_retry {
+            "Code mismatch — enter the pairing code shown in WeChat again: "
+        } else {
+            "Enter the pairing code shown in WeChat on your phone: "
+        };
+        eprint!("{}", prompt);
+        std::io::stderr().flush().ok();
+        let mut line = String::new();
+        std::io::stdin().lock().read_line(&mut line)?;
+        Ok(line.trim().to_string())
+    })
+    .await
+    .map_err(|e| WeChatBotError::Auth(format!("pairing code prompt failed: {e}")))?
+}
+
 /// Bot configuration options.
 pub struct BotOptions {
     pub base_url: Option<String>,
@@ -29,6 +48,10 @@ pub struct BotOptions {
     /// `base_info.bot_agent` on every API request (e.g. "MyApp/1.2 (prod)").
     /// Invalid values fall back to `protocol::default_bot_agent()`.
     pub bot_agent: Option<String>,
+    /// Called when the server requires a pairing code (the digits shown in
+    /// WeChat on the user's phone). The argument is true when a previously
+    /// submitted code was rejected. Defaults to a stdin prompt.
+    pub on_verify_code: Option<Box<dyn Fn(bool) -> String + Send + Sync>>,
 }
 
 impl Default for BotOptions {
@@ -39,6 +62,7 @@ impl Default for BotOptions {
             on_qr_url: None,
             on_error: None,
             bot_agent: None,
+            on_verify_code: None,
         }
     }
 }
@@ -56,6 +80,7 @@ pub struct WeChatBot {
     stopped: RwLock<bool>,
     on_qr_url: Option<Box<dyn Fn(&str) + Send + Sync>>,
     on_error: Option<Box<dyn Fn(&WeChatBotError) + Send + Sync>>,
+    on_verify_code: Option<Box<dyn Fn(bool) -> String + Send + Sync>>,
 }
 
 impl WeChatBot {
@@ -76,6 +101,7 @@ impl WeChatBot {
             stopped: RwLock::new(false),
             on_qr_url: opts.on_qr_url,
             on_error: opts.on_error,
+            on_verify_code: opts.on_verify_code,
         }
     }
 
@@ -130,20 +156,49 @@ impl WeChatBot {
 
             let mut last_status = String::new();
             let mut current_poll_base_url = Self::FIXED_QR_BASE_URL.to_string();
+            // Pairing code awaiting server verification (pair-code login flow)
+            let mut pending_verify_code: Option<String> = None;
             loop {
                 let status = self
                     .client
-                    .poll_qr_status(&current_poll_base_url, &qr.qrcode)
+                    .poll_qr_status(
+                        &current_poll_base_url,
+                        &qr.qrcode,
+                        pending_verify_code.as_deref(),
+                    )
                     .await?;
 
                 if status.status != last_status {
                     last_status = status.status.clone();
                     match status.status.as_str() {
-                        "scaned" => info!("QR scanned — confirm in WeChat"),
+                        "scaned" => {
+                            // A pending pairing code that leads back to
+                            // `scaned` was accepted
+                            pending_verify_code = None;
+                            info!("QR scanned — confirm in WeChat");
+                        }
                         "expired" => warn!("QR expired — requesting new one"),
                         "confirmed" => info!("Login confirmed"),
                         _ => {}
                     }
+                }
+
+                // Pair-code challenge: ask the user for the digits shown in WeChat
+                if status.status == "need_verifycode" {
+                    let is_retry = pending_verify_code.is_some();
+                    let code = match self.on_verify_code {
+                        Some(ref cb) => cb(is_retry),
+                        None => read_verify_code_from_stdin(is_retry).await?,
+                    };
+                    pending_verify_code = Some(code);
+                    continue; // Re-poll immediately with the code attached
+                }
+
+                // Too many wrong pairing codes: server blocked this QR — get a new one
+                if status.status == "verify_code_blocked" {
+                    warn!("Pairing code blocked after repeated mismatches — requesting new QR");
+                    pending_verify_code = None;
+                    break; // Outer loop requests a new QR (counts toward refresh limit)
                 }
 
                 if status.status == "confirmed" {

--- a/rust/src/protocol.rs
+++ b/rust/src/protocol.rs
@@ -260,12 +260,24 @@ impl ILinkClient {
         Ok(resp.json().await?)
     }
 
-    pub async fn poll_qr_status(&self, base_url: &str, qrcode: &str) -> Result<QrStatusResponse> {
-        let url = format!(
+    /// Poll the QR scan status.
+    ///
+    /// `verify_code` submits a pairing code after the server answered
+    /// `need_verifycode` (the digits shown in WeChat on the user's phone).
+    pub async fn poll_qr_status(
+        &self,
+        base_url: &str,
+        qrcode: &str,
+        verify_code: Option<&str>,
+    ) -> Result<QrStatusResponse> {
+        let mut url = format!(
             "{}/ilink/bot/get_qrcode_status?qrcode={}",
             base_url,
             urlencoding::encode(qrcode)
         );
+        if let Some(code) = verify_code {
+            url.push_str(&format!("&verify_code={}", urlencoding::encode(code)));
+        }
         let resp = self
             .http
             .get(&url)


### PR DESCRIPTION
## Summary

Part 3 of 3 porting upstream [openclaw-weixin](https://github.com/Tencent/openclaw-weixin) v2.1.7 → v2.4.6 protocol changes (part 1: #85, part 2: #86).

**Stacked on #86** — merge that first; this PR then retargets to `main` with only the pair-code commit.

Ports the v2.3.1 pair-code login flow: scanning the QR can trigger a server-side pairing challenge where the user must enter digits shown in WeChat on their phone. Without this handling, login dead-ends for affected accounts (the poll loop just spins).

- `get_qrcode_status` accepts an optional `verify_code` query param.
- **`need_verifycode`**: obtain a code (developer callback or stdin fallback) and re-poll immediately with it attached. Receiving `need_verifycode` again means the code was rejected — re-prompt with `isRetry=true`. Receiving `scaned` means it was accepted.
- **`verify_code_blocked`**: too many wrong codes; the QR is dead. Clear the pending code and request a fresh QR, counting toward the existing refresh limit (same as `expired`).
- New optional callback in each SDK: `onVerifyCode(isRetry)` (Node), `on_verify_code` (Python/Rust), `OnVerifyCode` (Go). Default is a stdin prompt (async-safe: `readline/promises`, `asyncio.to_thread`, `spawn_blocking`, `bufio`).
- `docs/protocol.md` documents the param and both statuses.

## Test plan

- [x] Node: `tsc --noEmit` + vitest (77 passed)
- [x] Go: `go build ./... && go vet ./... && go test ./...`
- [x] Rust: `cargo test` + `cargo fmt --check` clean
- [x] Python: pytest (30 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)