### PR TITLE
fix(ci): use stable Go toolchain — 1.22 binaries crash on new macOS runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22"
+          # Go ≤1.23.2 binaries lack LC_UUID and are killed by dyld on current
+          # macos-latest runner images; use a current stable toolchain.
+          go-version: "stable"
       - run: go build ./...
       - run: go test ./...
 

--- a/.github/workflows/release-binaries.yml
+++ b/.github/workflows/release-binaries.yml
@@ -38,7 +38,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.22'
+          # Keep in sync with ci.yml: Go ≤1.23.2 binaries lack LC_UUID and are
+          # killed by dyld on current macOS runner images.
+          go-version: 'stable'
 
       - name: Build
         working-directory: golang


### PR DESCRIPTION
## Summary

Every Go (macos-latest) CI job currently fails with:

```
dyld[1724]: missing LC_UUID load command
signal: abort trap
FAIL	github.com/corespeed-io/wechatbot/golang	0.002s
```

Go ≤1.23.2 emits binaries without an `LC_UUID` load command; the dyld on the updated `macos-latest` runner image refuses to load them. Main last ran CI in April (green) — any PR opened now hits this regardless of its content (see #85/#86).

Fix: stop pinning `go-version: "1.22"` in `ci.yml` and `release-binaries.yml`; use `stable`. `golang/go.mod` still declares `go 1.22` as the minimum language version, so library consumers are unaffected.

## Test plan

- [x] CI on this PR: Go (macos-latest) goes green (the only failing job before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)