### PR TITLE
chore: release minor versions for openclaw-weixin v2.4.6 protocol sync

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@wechatbot/wechatbot",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "description": "WeChat iLink Bot SDK — modular, extensible, production-grade",
   "type": "module",
   "exports": {

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "wechatbot-sdk"
-version = "0.2.1"
+version = "0.3.0"
 description = "WeChat iLink Bot SDK for Python — async, typed, production-grade"
 readme = "README.md"
 license = { text = "MIT" }

--- a/rust/Cargo.lock
+++ b/rust/Cargo.lock
@@ -1764,7 +1764,7 @@ dependencies = [
 
 [[package]]
 name = "wechatbot"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "aes",
  "base64",

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wechatbot"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "WeChat iLink Bot SDK for Rust"
 license = "MIT"

--- a/rust/src/bot.rs
+++ b/rust/src/bot.rs
@@ -194,10 +194,10 @@ impl WeChatBot {
                     continue; // Re-poll immediately with the code attached
                 }
 
-                // Too many wrong pairing codes: server blocked this QR — get a new one
+                // Too many wrong pairing codes: server blocked this QR — get a new
+                // one (the fresh QR loop re-initializes pending_verify_code)
                 if status.status == "verify_code_blocked" {
                     warn!("Pairing code blocked after repeated mismatches — requesting new QR");
-                    pending_verify_code = None;
                     break; // Outer loop requests a new QR (counts toward refresh limit)
                 }
 


### PR DESCRIPTION
## Summary

Version bumps for the upstream protocol sync (#85, #86, #87):

| SDK | Version | Publish trigger |
|-----|---------|-----------------|
| Node.js | 2.1.1 → **2.2.0** | tag `node-v2.2.0` |
| Python | 0.2.1 → **0.3.0** | tag `py-v0.3.0` |
| Rust | 0.3.2 → **0.4.0** | tag `rust-v0.4.0` |
| Go | git tag only | `golang/v0.2.0` |

Minor bumps: all three PRs add protocol features (new endpoints, new bot options). Rust jumps to 0.4.0 because public signatures changed (`ILinkClient::get_qr_code`/`poll_qr_status` params, new `BotOptions` fields) — allowed in a 0.x minor.

Also removes a dead `pending_verify_code = None` assignment in the Rust pair-code loop (rustc `unused_assignments` warning introduced by the #87 merge).

Tags will be pushed after this merges to fire the npm/PyPI/crates.io publish workflows.

## Test plan

- [x] `cargo test` + `cargo fmt --check` (warning-free build)
- [x] CI on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)