### PR TITLE
chore(ci): add deployment environments to npm and crates.io publish jobs

### DIFF
--- a/.github/workflows/publish-crate.yml
+++ b/.github/workflows/publish-crate.yml
@@ -25,6 +25,10 @@ jobs:
     defaults:
       run:
         working-directory: rust
+    # Named environment so publishes show up under GitHub → Deployments
+    environment:
+      name: crates-io
+      url: https://crates.io/crates/wechatbot
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -26,6 +26,10 @@ jobs:
     defaults:
       run:
         working-directory: nodejs
+    # Named environment so publishes show up under GitHub → Deployments
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@wechatbot/wechatbot
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Only the PyPI publish job declares a GitHub `environment:`, so the Deployments panel showed PyPI releases exclusively. Add `environment: npm` and `environment: crates-io` (with package URLs) to the other two publish jobs so all three registries appear under Deployments.

Purely cosmetic — auth is unchanged (npm OIDC trusted publishing doesn't pin an environment name; crates.io uses the token secret).

🤖 Generated with [Claude Code](https://claude.com/claude-code)