### PR TITLE
docs: add multi-tenant / multi-account section to README

### DIFF
--- a/README.EN.MD
+++ b/README.EN.MD
@@ -153,6 +153,34 @@ All SDKs share the following capabilities:
 | 📝 Structured Logging | Leveled, context-aware, pluggable transports |
 | 🏗️ Message Builder | `.text().image().file().build()` chaining API |
 
+## 👥 Multi-Tenant / Multi-Account
+
+Every bot instance is fully isolated (own HTTP client, events, message poller) with no global state and no local ports — one backend process can run many WeChat accounts side by side. The QR code is delivered via callback, so you can push it to a web frontend and let each user scan from their own page:
+
+```typescript
+// One instance per tenant, credentials isolated per tenant
+const bot = new WeChatBot({
+  storage: new PostgresStorage(pool, tenantId),  // or { storageDir: `/data/${tenantId}` }
+})
+
+await bot.login({
+  callbacks: {
+    onQrUrl: (url) => pushQrToWebUI(tenantId, url),  // render on that user's page
+    onScanned: () => notify(tenantId, 'Scanned — waiting for confirmation'),
+    onExpired: () => refreshQr(tenantId),
+  },
+})
+await bot.start()
+```
+
+Three things to watch:
+
+1. **Storage isolation** — each account needs its own `storageDir` or storage namespace; sharing one overwrites credentials.
+2. **One live instance per account** — only one poller per account across your whole fleet, or message cursors overwrite each other; use an advisory lock or lease table in multi-machine deployments.
+3. **Restart without rescanning** — credentials are persisted, so `login()` restores the session after a restart.
+
+Full example (including a custom PostgreSQL storage) in the [Node.js SDK docs](https://github.com/jiweiyuan/wechatbot-landing).
+
 ## 🏗 Architecture
 
 ```mermaid

--- a/README.md
+++ b/README.md
@@ -102,6 +102,34 @@ bot.run().await?;
 | 📝 结构化日志 | 分级、上下文感知、可插拔传输 |
 | 🏗️ 消息构建器 | `.text().image().file().build()` 链式 API |
 
+## 👥 多租户 / 多账号
+
+每个 Bot 实例完全隔离（独立 HTTP 客户端、事件、消息轮询器），无全局状态、不占本地端口——一个后端进程可以同时运行多个微信账号。二维码通过回调返回，可推给 Web 前端让每个用户在自己的页面上扫码：
+
+```typescript
+// 每个租户一个实例，凭证按租户隔离
+const bot = new WeChatBot({
+  storage: new PostgresStorage(pool, tenantId),  // 或 { storageDir: `/data/${tenantId}` }
+})
+
+await bot.login({
+  callbacks: {
+    onQrUrl: (url) => pushQrToWebUI(tenantId, url),  // 推给该用户的页面扫码
+    onScanned: () => notify(tenantId, '已扫码，等待确认'),
+    onExpired: () => refreshQr(tenantId),
+  },
+})
+await bot.start()
+```
+
+三条注意事项：
+
+1. **存储隔离** — 每个账号必须有独立的 `storageDir` 或存储命名空间，共用会互相覆盖凭证。
+2. **单账号单实例** — 同一账号在全集群只能有一个实例轮询消息，否则游标互相覆盖；多机部署用 advisory lock 或租约表选主。
+3. **重启免扫码** — 凭证已持久化，重启后 `login()` 自动恢复会话。
+
+完整示例（含 PostgreSQL 自定义存储）见 [Node.js SDK 文档](https://github.com/jiweiyuan/wechatbot-landing)。
+
 ## 🏗 架构
 
 ```mermaid


### PR DESCRIPTION
## Summary

Adds a **Multi-Tenant / Multi-Account** section to both `README.md` and `README.EN.MD`, between the features tables and the architecture diagram.

The SDK already supports running multiple WeChat accounts in one backend process — every bot instance is fully isolated (own HTTP client, events, poller; no global state, no local ports) — but this was undocumented. The new section covers:

- One instance per tenant with per-tenant credential storage (`storageDir` or a custom `Storage` such as PostgreSQL)
- QR delivery via the `onQrUrl` login callback so each user scans from their own web page
- Three operational caveats: storage isolation, single poller per account across the fleet, and restart recovery without rescanning

Companion docs (full PostgreSQL storage example) already live on the landing site: jiweiyuan/wechatbot-landing@ca8053f.

🤖 Generated with [Claude Code](https://claude.com/claude-code)