### PR TITLE
docs: add Star History chart to README

### DIFF
--- a/README.EN.MD
+++ b/README.EN.MD
@@ -238,6 +238,10 @@ wechatbot/
     └── architecture.md    #   Architecture & SDK Comparison
 ```
 
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=corespeed-io/wechatbot&type=Date)](https://star-history.com/#corespeed-io/wechatbot&Date)
+
 ## 📄 License
 
 [MIT](LICENSE)

--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ wechatbot/
     └── architecture.md    #   架构 & SDK 对比
 ```
 
+## ⭐ Star History
+
+[![Star History Chart](https://api.star-history.com/svg?repos=corespeed-io/wechatbot&type=Date)](https://star-history.com/#corespeed-io/wechatbot&Date)
+
 ## 📄 License
 
 [MIT](LICENSE)


### PR DESCRIPTION
Adds a Star History chart (via star-history.com) before the License section in both `README.md` and `README.EN.MD`. The badge auto-updates over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
