### PR TITLE
docs: point openclaw-weixin-cli link at upstream GitHub repo

### DIFF
--- a/README.EN.MD
+++ b/README.EN.MD
@@ -15,7 +15,7 @@
 
 [中文文档](README.md)
 
-Connect any agent to WeChat in 5 minutes. Inspired by [openclaw-weixin-cli](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin).
+Connect any agent to WeChat in 5 minutes. Inspired by [openclaw-weixin-cli](https://github.com/Tencent/openclaw-weixin).
 
 ## 📦 SDKs
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [English](README.EN.MD)
 
-5 分钟让任何 Agent 接入微信。灵感来自 [openclaw-weixin-cli](https://www.npmjs.com/package/@tencent-weixin/openclaw-weixin)。
+5 分钟让任何 Agent 接入微信。灵感来自 [openclaw-weixin-cli](https://github.com/Tencent/openclaw-weixin)。
 
 ## 📦 SDK 一览
 


### PR DESCRIPTION
Changes the "inspired by openclaw-weixin-cli" link in both READMEs from the npm package page to the upstream GitHub repository: https://github.com/Tencent/openclaw-weixin

🤖 Generated with [Claude Code](https://claude.com/claude-code)