### PR TITLE
docs: fix upstream project name to openclaw-weixin

### DIFF
--- a/README.EN.MD
+++ b/README.EN.MD
@@ -15,7 +15,7 @@
 
 [中文文档](README.md)
 
-Connect any agent to WeChat in 5 minutes. Inspired by [openclaw-weixin-cli](https://github.com/Tencent/openclaw-weixin).
+Connect any agent to WeChat in 5 minutes. Inspired by [openclaw-weixin](https://github.com/Tencent/openclaw-weixin).
 
 ## 📦 SDKs
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 
 [English](README.EN.MD)
 
-5 分钟让任何 Agent 接入微信。灵感来自 [openclaw-weixin-cli](https://github.com/Tencent/openclaw-weixin)。
+5 分钟让任何 Agent 接入微信。灵感来自 [openclaw-weixin](https://github.com/Tencent/openclaw-weixin)。
 
 ## 📦 SDK 一览
 


### PR DESCRIPTION
The link text still read `openclaw-weixin-cli`; the upstream project is named `openclaw-weixin` (https://github.com/Tencent/openclaw-weixin). Fixes both READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)