### PR TITLE
feat(rust): add send_typing_with_status

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -117,8 +117,11 @@ bot.reply(&msg, "Echo: hello").await?;
 // Send to user (needs prior context_token)
 bot.send(user_id, "Hello").await?;
 
-// Typing indicator
+// Start typing indicator (status = 1)
 bot.send_typing(user_id).await?;
+
+// Set typing status explicitly (1 = start, 2 = stop)
+bot.send_typing_with_status(user_id, 2).await?;
 ```
 
 ### Media Operations

--- a/rust/src/bot.rs
+++ b/rust/src/bot.rs
@@ -277,6 +277,13 @@ impl WeChatBot {
 
     /// Show "typing..." indicator.
     pub async fn send_typing(&self, user_id: &str) -> Result<()> {
+        self.send_typing_with_status(user_id, 1).await
+    }
+
+    /// Set the "typing..." indicator status.
+    ///
+    /// Status `1` starts the indicator, while status `2` stops it.
+    pub async fn send_typing_with_status(&self, user_id: &str, status: i32) -> Result<()> {
         let ct = self.context_tokens.read().await.get(user_id).cloned();
         let ct = ct.ok_or_else(|| WeChatBotError::NoContext(user_id.to_string()))?;
         let (base_url, token) = self.get_auth().await?;
@@ -286,7 +293,7 @@ impl WeChatBot {
             .await?;
         if let Some(ticket) = config.typing_ticket {
             self.client
-                .send_typing(&base_url, &token, user_id, &ticket, 1)
+                .send_typing(&base_url, &token, user_id, &ticket, status)
                 .await?;
         }
         Ok(())

--- a/rust/tests/typing_api.rs
+++ b/rust/tests/typing_api.rs
@@ -1,0 +1,12 @@
+use wechatbot::{BotOptions, WeChatBot};
+
+#[test]
+fn typing_status_api_is_public_and_backwards_compatible() {
+    let bot = WeChatBot::new(BotOptions::default());
+
+    // Existing API remains available.
+    drop(bot.send_typing("user-id"));
+
+    // New API allows callers to choose the protocol status.
+    drop(bot.send_typing_with_status("user-id", 2));
+}


### PR DESCRIPTION
## Summary

- Add `WeChatBot::send_typing_with_status(user_id, status)` to the Rust SDK.
- Preserve the existing `send_typing(user_id)` behavior by delegating to status `1`.
- Document status `1` as start and status `2` as stop.
- Add a public API regression test covering both the existing and new method signatures.

## Motivation

The iLink `/sendtyping` endpoint supports status `1` and `2`, and the low-level Rust `ILinkClient::send_typing` method already accepts a status parameter. However, the high-level `WeChatBot::send_typing` method hardcodes status `1`, so Rust callers cannot explicitly stop the typing indicator through the high-level API.

## Developer impact

Existing calls remain unchanged:

```rust
bot.send_typing(user_id).await?;
```

Callers can now explicitly stop the indicator:

```rust
bot.send_typing_with_status(user_id, 2).await?;
```

## Backward compatibility

No existing public method signatures are changed. Existing calls to `send_typing(user_id)` retain their current status-`1` behavior.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo build`
- [x] `cargo test` (49 unit tests, 1 public API integration test, and 2 doc tests)
- [x] `git diff --check upstream/main...HEAD`

Supersedes #100, which was closed to resubmit this change from a fresh branch.
