### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.EN.MD
+++ b/README.EN.MD
@@ -240,7 +240,7 @@ wechatbot/
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=corespeed-io/wechatbot&type=Date)](https://star-history.com/#corespeed-io/wechatbot&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=corespeed-io/wechatbot&type=Date)](https://star-history.dera.page/#corespeed-io/wechatbot&Date)
 
 ## 📄 License
 

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ wechatbot/
 
 ## ⭐ Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=corespeed-io/wechatbot&type=Date)](https://star-history.com/#corespeed-io/wechatbot&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=corespeed-io/wechatbot&type=Date)](https://star-history.dera.page/#corespeed-io/wechatbot&Date)
 
 ## 📄 License
 


### PR DESCRIPTION
The star history chart in README.md and README.EN.MD is currently broken and does not render reliably. This change points both the chart image and its wrapping link at the working mirror so the chart displays again in the README.